### PR TITLE
Add Yelp scraper, review sync, and fetch command

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ bun run dev config get foo
 # stderr: Unknown config key: foo
 ```
 
+### Download reviews
+
+```bash
+bun run dev business add "Meet Fresh" "https://www.yelp.com/biz/meet-fresh-temple-city"
+```
+
 ### Input validation
 
 - Business name must be non-empty

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ bun run dev <command>
 
 ```bash
 # Register a business
-bun run dev business add "Taco Palace" "https://www.yelp.com/biz/taco-palace"
+bun run dev business add "Meet Fresh" "https://www.yelp.com/biz/meet-fresh-temple-city"
 # → {"id":1,"name":"Taco Palace","yelpUrl":"https://www.yelp.com/biz/taco-palace","createdAt":"2026-04-08 12:00:00"}
 
 # List all businesses
@@ -61,7 +61,7 @@ bun run dev config get foo
 ### Download reviews
 
 ```bash
-bun run dev business add "Meet Fresh" "https://www.yelp.com/biz/meet-fresh-temple-city"
+bun run dev fetch -b 1 --pages 1
 ```
 
 ### Input validation

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,6 +22,7 @@ test/
   business.test.ts    — business service tests
   config.test.ts      — config service tests
   review.test.ts      — review service tests
+  scraper.test.ts     — scraper parsing / helper tests
 drizzle/
   0000_*.sql          — initial migration (tables)
   0001_*.sql          — add unique index on businesses.yelp_url
@@ -92,16 +93,43 @@ syncReviews(db, businessId, scrapedReviews[])  // → newly inserted review rows
 ### Scraper (`src/services/scraper.ts`)
 
 ```typescript
-scrapeReviews(yelpUrl, maxPages)         // → ScrapedReview[]; shells out to openclaw browser
+scrapeReviews(yelpUrl, maxPages)         // → ScrapedReview[]; orchestrates openclaw browser
 parseReviewsFromSnapshot(snapshot)       // → ScrapedReview[]; pure parsing of snapshot text
+findNextPageRef(snapshot)                // → string | null; finds "Next" link ref for pagination
+extractTargetId(jsonOutput)              // → string | null; parses `openclaw browser open` output
+extractTabIds(jsonOutput)                // → string[];      parses `openclaw browser tabs` output
 ```
 
-- Checks that `openclaw` CLI is installed; throws helpfully if missing.
-- Navigates to the business Yelp URL with `?sort_by=date_desc` (Newest First).
-- Takes an AI snapshot via `openclaw browser snapshot` and parses review data from the structured text output.
-- Paginates by finding and clicking the "Next" link in the snapshot, up to `maxPages`.
-- Closes the browser after scraping completes (or on error) via a `finally` block.
-- Uses `execFileSync` (no shell) to avoid command injection.
+All `openclaw browser` invocations go through a single `ocBrowser(args, timeoutMs)` helper that shells out with `execFileSync` (no shell — command injection safe) and a 30s default timeout.
+
+**Orchestration flow (`scrapeReviews`):**
+
+1. Verifies the `openclaw` CLI is installed; throws a helpful install hint if missing.
+2. Normalizes the URL to `<yelpUrl>?sort_by=date_desc` (Newest First).
+3. Snapshots existing browser tabs via `openclaw browser --json tabs` so it can later tell which tab(s) it opened.
+4. Opens the URL (`openclaw browser open`), then re-reads the tab list and diffs to record the newly-opened tab IDs.
+5. Waits for the text "Recommended Reviews" to appear (`openclaw browser wait --text …`, 15s page-load timeout).
+6. For each page up to `maxPages`:
+   - On pages after the first, takes a snapshot, locates the "Next" link ref with `findNextPageRef`, clicks it, and waits 3s for the next page to render. Breaks the loop if no Next link exists.
+   - Takes a snapshot and runs `parseReviewsFromSnapshot` to extract review rows.
+7. In a `finally` block, closes only the tabs that *this* invocation opened. The browser itself is intentionally left running so subsequent fetches (and user sessions) can reuse it — this avoids re-triggering DataDome CAPTCHAs.
+
+**Output handling:** `openclaw` can print plugin banner lines on stdout before its JSON body. `stripNonJsonPrefix` trims everything up to the first `{` so `JSON.parse` can succeed. Both `extractTargetId` and `extractTabIds` use it.
+
+**Snapshot parsing (`parseReviewsFromSnapshot`):** Splits the snapshot on `- region "…" [ref=…]:` markers, then for each region extracts:
+
+| Field | Source regex |
+|---|---|
+| `userId` | `/user_details?userid=…` URL in the region |
+| `reviewerName` | region title (must end with `.` — skips non-reviewer regions like "Username" or "Recommended Reviews") |
+| `reviewerLocation` | `- generic` line matching `City, ST` pattern (nullable) |
+| `rating` | `img "N star rating"` |
+| `postedAtRaw` / `postedAtIso` | `- generic` line with a `Mon DD, YYYY` date, converted to `YYYY-MM-DD` |
+| `reviewText` | `- paragraph` line content |
+
+Any region missing `userId`, `rating`, date, or review text is skipped silently.
+
+**Pagination parsing (`findNextPageRef`):** Matches `link "Next"(\s\[\w+\])*\s\[ref=…]`. The optional `\[\w+\]` group lets it match both `link "Next" [ref=…]` (first page) and `link "Next" [active] [ref=…]` (subsequent pages). It intentionally does not match `button "Next"`, which Yelp uses for the photo gallery.
 
 ## CLI Layer
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -92,13 +92,15 @@ syncReviews(db, businessId, scrapedReviews[])  // → newly inserted review rows
 ### Scraper (`src/services/scraper.ts`)
 
 ```typescript
-scrapeReviews(yelpUrl, maxPages)  // → ScrapedReview[]; shells out to openclaw browser
+scrapeReviews(yelpUrl, maxPages)         // → ScrapedReview[]; shells out to openclaw browser
+parseReviewsFromSnapshot(snapshot)       // → ScrapedReview[]; pure parsing of snapshot text
 ```
 
 - Checks that `openclaw` CLI is installed; throws helpfully if missing.
 - Navigates to the business Yelp URL with `?sort_by=date_desc` (Newest First).
 - Takes an AI snapshot via `openclaw browser snapshot` and parses review data from the structured text output.
 - Paginates by finding and clicking the "Next" link in the snapshot, up to `maxPages`.
+- Closes the browser after scraping completes (or on error) via a `finally` block.
 - Uses `execFileSync` (no shell) to avoid command injection.
 
 ## CLI Layer

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,19 +8,24 @@ src/
   commands/
     business.ts       — business add/list/remove subcommands
     config.ts         — config get/set subcommands
+    fetch.ts          — fetch reviews for a business
   db/
     schema.ts         — Drizzle ORM schema (4 tables)
     index.ts          — getDatabase(dataDir) auto-init + migrations
   services/
     business.ts       — business CRUD with Zod validation
     config.ts         — config key-value get/set with defaults
+    review.ts         — review sync/dedup logic with Zod validation
+    scraper.ts        — Yelp scraper via openclaw browser CLI
 test/
   db.test.ts          — database layer tests
   business.test.ts    — business service tests
   config.test.ts      — config service tests
+  review.test.ts      — review service tests
 drizzle/
   0000_*.sql          — initial migration (tables)
   0001_*.sql          — add unique index on businesses.yelp_url
+  0002_*.sql          — replace review_url with user_id, add composite unique index
 ```
 
 ## Database Layer
@@ -40,7 +45,7 @@ The production data directory is `~/.kiwiberry/`, with the DB file at `~/.kiwibe
 | Table | Key Columns | Constraints | Relationships |
 |---|---|---|---|
 | `businesses` | id, name, yelp_url, created_at | yelp_url UNIQUE | — |
-| `reviews` | id, business_id, reviewer_name, reviewer_location, rating, posted_at_raw, posted_at_iso, review_text, review_url, fetched_at_iso, location_name | review_url UNIQUE | FK → businesses (CASCADE) |
+| `reviews` | id, business_id, user_id, reviewer_name, reviewer_location, rating, posted_at_raw, posted_at_iso, review_text, fetched_at_iso, location_name | UNIQUE(business_id, user_id, posted_at_iso) | FK → businesses (CASCADE) |
 | `draft_responses` | id, review_id, response_text, created_at | — | FK → reviews (CASCADE) |
 | `config` | key (PK), value | — | — |
 
@@ -61,6 +66,40 @@ removeBusiness(db, id)            // → true if deleted, false if not found
 - Zod validates name (non-empty) and yelpUrl (valid URL) before insert.
 - Duplicate Yelp URLs are rejected at the DB level (unique constraint), not via a preflight read.
 
+### Config Service (`src/services/config.ts`)
+
+```typescript
+setConfig(db, key, value)  // → void; upserts key-value pair (insert or overwrite)
+getConfig(db, key)         // → string; returns DB value, then default, or throws for unknown key
+```
+
+- Defaults are defined in-code: `max-pages` = `"2"`.
+- `setConfig` uses `onConflictDoUpdate` so setting the same key twice overwrites the value.
+- `getConfig` checks the DB first, falls back to defaults, and throws `Unknown config key: <key>` for unrecognized keys.
+
+### Review Service (`src/services/review.ts`)
+
+```typescript
+syncReviews(db, businessId, scrapedReviews[])  // → newly inserted review rows
+```
+
+- Validates each review with Zod (userId, reviewerName, rating 1–5, postedAtRaw, postedAtIso, reviewText, fetchedAtIso required).
+- Deduplicates by composite key: `businessId + userId + postedAtIso`.
+- Dedup covers both existing DB rows and duplicates within the same batch.
+- Throws if `businessId` does not exist.
+
+### Scraper (`src/services/scraper.ts`)
+
+```typescript
+scrapeReviews(yelpUrl, maxPages)  // → ScrapedReview[]; shells out to openclaw browser
+```
+
+- Checks that `openclaw` CLI is installed; throws helpfully if missing.
+- Navigates to the business Yelp URL with `?sort_by=date_desc` (Newest First).
+- Takes an AI snapshot via `openclaw browser snapshot` and parses review data from the structured text output.
+- Paginates by finding and clicking the "Next" link in the snapshot, up to `maxPages`.
+- Uses `execFileSync` (no shell) to avoid command injection.
+
 ## CLI Layer
 
 Uses citty (unjs/citty). The root command is defined in `src/index.ts`. Commands are thin wiring — argument parsing, service calls, and JSON output. No business logic in command definitions.
@@ -74,22 +113,10 @@ Uses citty (unjs/citty). The root command is defined in `src/index.ts`. Commands
 | `business remove <id>` | `{"removed":true,"id":N}` | "Business not found" / "ID must be a number" |
 | `config get <key>` | `{"key":"...","value":"..."}` | "Unknown config key: ..." |
 | `config set <key> <value>` | `{"key":"...","value":"..."}` | — |
+| `fetch -b <id> [--pages N]` | JSON array of new reviews | "Business not found" / "openclaw CLI is not installed" |
 
 All CLI output goes as JSON on stdout. Human-readable error messages go on stderr.
 
-### Config Service (`src/services/config.ts`)
-
-```typescript
-setConfig(db, key, value)  // → void; upserts key-value pair (insert or overwrite)
-getConfig(db, key)         // → string; returns DB value, then default, or throws for unknown key
-```
-
-- Defaults are defined in-code: `max-pages` = `"2"`.
-- `setConfig` uses `onConflictDoUpdate` so setting the same key twice overwrites the value.
-- `getConfig` checks the DB first, falls back to defaults, and throws `Unknown config key: <key>` for unrecognized keys.
-
 ## Planned Modules (Not Yet Built)
 
-- **Review Service** — sync logic, dedup by review_url
 - **Response Service** — save/list draft responses
-- **Scraper** — shells out to OpenClaw browser CLI to scrape Yelp pages

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,6 +26,7 @@ drizzle/
   0000_*.sql          — initial migration (tables)
   0001_*.sql          — add unique index on businesses.yelp_url
   0002_*.sql          — replace review_url with user_id, add composite unique index
+  0003_*.sql          — drop location_name column from reviews
 ```
 
 ## Database Layer
@@ -45,7 +46,7 @@ The production data directory is `~/.kiwiberry/`, with the DB file at `~/.kiwibe
 | Table | Key Columns | Constraints | Relationships |
 |---|---|---|---|
 | `businesses` | id, name, yelp_url, created_at | yelp_url UNIQUE | — |
-| `reviews` | id, business_id, user_id, reviewer_name, reviewer_location, rating, posted_at_raw, posted_at_iso, review_text, fetched_at_iso, location_name | UNIQUE(business_id, user_id, posted_at_iso) | FK → businesses (CASCADE) |
+| `reviews` | id, business_id, user_id, reviewer_name, reviewer_location, rating, posted_at_raw, posted_at_iso, review_text, fetched_at_iso | UNIQUE(business_id, user_id, posted_at_iso) | FK → businesses (CASCADE) |
 | `draft_responses` | id, review_id, response_text, created_at | — | FK → reviews (CASCADE) |
 | `config` | key (PK), value | — | — |
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -53,11 +53,19 @@ Tests exercise `getConfig` and `setConfig`:
 | setConfig stores a value and getConfig retrieves it | Round-trip: set then get returns stored value |
 | setConfig overwrites an existing value | Second set replaces first; get returns latest |
 
-## What to Test (per PRD)
+### Review Service (test/review.test.ts)
 
-- **Review Service** — dedup behavior, sync returns only new reviews
+Tests exercise `syncReviews`:
+
+| Test | What It Verifies |
+|---|---|
+| syncReviews inserts new reviews and returns them | Inserts multiple reviews, returns rows with id and businessId |
+| syncReviews deduplicates by businessId + userId + postedAtIso | Re-syncing same reviews returns empty array |
+| syncReviews rejects invalid review data | Zod validation: empty userId throws |
+| syncReviews deduplicates within the same batch | Duplicate entries in one call produce only one insert |
+| syncReviews throws for non-existent business | Throws `Business not found: N` for missing ID |
 
 ## What Not to Test
 
 - **CLI Commands** — thin wiring layer, validate manually
-- **Scraper** — depends on external OpenClaw subprocess and live Yelp pages
+- **Scraper** — depends on external openclaw subprocess and live Yelp pages

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -65,7 +65,17 @@ Tests exercise `syncReviews`:
 | syncReviews deduplicates within the same batch | Duplicate entries in one call produce only one insert |
 | syncReviews throws for non-existent business | Throws `Business not found: N` for missing ID |
 
+### Scraper (test/scraper.test.ts)
+
+Tests exercise `parseReviewsFromSnapshot`:
+
+| Test | What It Verifies |
+|---|---|
+| parses a valid review block into a ScrapedReview | Extracts userId, name, location, rating, date, and text from snapshot |
+| skips non-reviewer regions | Regions not ending with "." (e.g., "Username") are ignored |
+| skips review blocks missing required fields | Missing userId, rating, date, or text → skipped |
+
 ## What Not to Test
 
 - **CLI Commands** — thin wiring layer, validate manually
-- **Scraper** — depends on external openclaw subprocess and live Yelp pages
+- **Scraper orchestration (`scrapeReviews`)** — depends on external openclaw subprocess and live Yelp pages

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -67,15 +67,44 @@ Tests exercise `syncReviews`:
 
 ### Scraper (test/scraper.test.ts)
 
-Tests exercise `parseReviewsFromSnapshot`:
+Tests exercise the pure helpers exported from `src/services/scraper.ts`. The end-to-end `scrapeReviews` orchestration is not tested here (see *What Not to Test*).
+
+`extractTabIds` — parses `openclaw browser --json tabs` output:
+
+| Test | What It Verifies |
+|---|---|
+| extracts all tab targetIds from openclaw tabs JSON output | Returns every `targetId` in the `tabs` array, in order |
+| returns empty array when no tabs | `{"tabs": []}` → `[]` |
+| returns empty array for invalid JSON | Malformed input doesn't throw |
+| strips non-JSON plugin output prefix before parsing | Plugin banner lines printed before the JSON body are ignored |
+
+`extractTargetId` — parses `openclaw browser open` output:
+
+| Test | What It Verifies |
+|---|---|
+| extracts targetId from openclaw open JSON output | Returns the top-level `targetId` string |
+| returns null when output has no targetId | `{}` → `null` |
+| returns null for invalid JSON | Malformed input doesn't throw |
+| strips non-JSON plugin output prefix before parsing | Plugin banner lines printed before the JSON body are ignored |
+
+`findNextPageRef` — locates the pagination "Next" link ref in a snapshot:
+
+| Test | What It Verifies |
+|---|---|
+| finds Next link ref on first page (no modifiers) | Matches `link "Next" [ref=…]` |
+| finds Next link ref when it has [active] modifier | Matches `link "Next" [active] [ref=…]` |
+| returns null when no Next link exists | Missing Next link → `null` |
+| ignores button "Next" (e.g. photo gallery) | Only `link` is matched, not `button` |
+
+`parseReviewsFromSnapshot` — extracts reviews from a Yelp AI snapshot:
 
 | Test | What It Verifies |
 |---|---|
 | parses a valid review block into a ScrapedReview | Extracts userId, name, location, rating, date, and text from snapshot |
-| skips non-reviewer regions | Regions not ending with "." (e.g., "Username") are ignored |
-| skips review blocks missing required fields | Missing userId, rating, date, or text → skipped |
+| skips non-reviewer regions | Regions whose title doesn't end with `.` (e.g. "Username", "Recommended Reviews") are ignored |
+| skips review blocks missing required fields | Missing userId, rating, date, or text → the block is skipped |
 
 ## What Not to Test
 
 - **CLI Commands** — thin wiring layer, validate manually
-- **Scraper orchestration (`scrapeReviews`)** — depends on external openclaw subprocess and live Yelp pages
+- **Scraper orchestration (`scrapeReviews`)** — depends on the external `openclaw` subprocess and live Yelp pages. Orchestration logic (tab-diff open/close, pagination loop, "Recommended Reviews" wait) is validated manually; the pure helpers it composes (`extractTabIds`, `extractTargetId`, `findNextPageRef`, `parseReviewsFromSnapshot`) are covered above.

--- a/drizzle/0002_replace_review_url_with_user_id.sql
+++ b/drizzle/0002_replace_review_url_with_user_id.sql
@@ -1,0 +1,22 @@
+-- Recreate reviews table: remove review_url, add user_id, add composite unique index
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `reviews_new` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`business_id` integer NOT NULL,
+	`user_id` text NOT NULL,
+	`reviewer_name` text NOT NULL,
+	`reviewer_location` text,
+	`rating` real NOT NULL,
+	`posted_at_raw` text NOT NULL,
+	`posted_at_iso` text NOT NULL,
+	`review_text` text NOT NULL,
+	`fetched_at_iso` text NOT NULL,
+	`location_name` text,
+	FOREIGN KEY (`business_id`) REFERENCES `businesses`(`id`) ON UPDATE no action ON DELETE cascade
+);--> statement-breakpoint
+INSERT INTO `reviews_new` (`id`, `business_id`, `user_id`, `reviewer_name`, `reviewer_location`, `rating`, `posted_at_raw`, `posted_at_iso`, `review_text`, `fetched_at_iso`, `location_name`)
+	SELECT `id`, `business_id`, '', `reviewer_name`, `reviewer_location`, `rating`, `posted_at_raw`, COALESCE(`posted_at_iso`, ''), `review_text`, `fetched_at_iso`, `location_name` FROM `reviews`;--> statement-breakpoint
+DROP TABLE `reviews`;--> statement-breakpoint
+ALTER TABLE `reviews_new` RENAME TO `reviews`;--> statement-breakpoint
+CREATE UNIQUE INDEX `reviews_biz_user_date` ON `reviews` (`business_id`, `user_id`, `posted_at_iso`);--> statement-breakpoint
+PRAGMA foreign_keys=ON;

--- a/drizzle/0003_drop_location_name.sql
+++ b/drizzle/0003_drop_location_name.sql
@@ -1,0 +1,18 @@
+CREATE TABLE `reviews_new` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`business_id` integer NOT NULL,
+	`user_id` text NOT NULL,
+	`reviewer_name` text NOT NULL,
+	`reviewer_location` text,
+	`rating` real NOT NULL,
+	`posted_at_raw` text NOT NULL,
+	`posted_at_iso` text NOT NULL,
+	`review_text` text NOT NULL,
+	`fetched_at_iso` text NOT NULL,
+	FOREIGN KEY (`business_id`) REFERENCES `businesses`(`id`) ON UPDATE no action ON DELETE cascade
+);--> statement-breakpoint
+INSERT INTO `reviews_new` (`id`, `business_id`, `user_id`, `reviewer_name`, `reviewer_location`, `rating`, `posted_at_raw`, `posted_at_iso`, `review_text`, `fetched_at_iso`)
+	SELECT `id`, `business_id`, `user_id`, `reviewer_name`, `reviewer_location`, `rating`, `posted_at_raw`, `posted_at_iso`, `review_text`, `fetched_at_iso` FROM `reviews`;--> statement-breakpoint
+DROP TABLE `reviews`;--> statement-breakpoint
+ALTER TABLE `reviews_new` RENAME TO `reviews`;--> statement-breakpoint
+CREATE UNIQUE INDEX `reviews_biz_user_date` ON `reviews` (`business_id`,`user_id`,`posted_at_iso`);

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,253 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "prevId": "c437e810-feb8-4c32-8a2a-677246a593c9",
+  "tables": {
+    "businesses": {
+      "name": "businesses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "yelp_url": {
+          "name": "yelp_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "businesses_yelp_url_unique": {
+          "name": "businesses_yelp_url_unique",
+          "columns": [
+            "yelp_url"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "config": {
+      "name": "config",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "draft_responses": {
+      "name": "draft_responses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response_text": {
+          "name": "response_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_responses_review_id_reviews_id_fk": {
+          "name": "draft_responses_review_id_reviews_id_fk",
+          "tableFrom": "draft_responses",
+          "tableTo": "reviews",
+          "columnsFrom": [
+            "review_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reviews": {
+      "name": "reviews",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "business_id": {
+          "name": "business_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reviewer_name": {
+          "name": "reviewer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reviewer_location": {
+          "name": "reviewer_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "posted_at_raw": {
+          "name": "posted_at_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "posted_at_iso": {
+          "name": "posted_at_iso",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "review_text": {
+          "name": "review_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fetched_at_iso": {
+          "name": "fetched_at_iso",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_name": {
+          "name": "location_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reviews_biz_user_date": {
+          "name": "reviews_biz_user_date",
+          "columns": [
+            "business_id",
+            "user_id",
+            "posted_at_iso"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "reviews_business_id_businesses_id_fk": {
+          "name": "reviews_business_id_businesses_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "businesses",
+          "columnsFrom": [
+            "business_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,246 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+  "prevId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "tables": {
+    "businesses": {
+      "name": "businesses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "yelp_url": {
+          "name": "yelp_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "businesses_yelp_url_unique": {
+          "name": "businesses_yelp_url_unique",
+          "columns": [
+            "yelp_url"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "config": {
+      "name": "config",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "draft_responses": {
+      "name": "draft_responses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response_text": {
+          "name": "response_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_responses_review_id_reviews_id_fk": {
+          "name": "draft_responses_review_id_reviews_id_fk",
+          "tableFrom": "draft_responses",
+          "tableTo": "reviews",
+          "columnsFrom": [
+            "review_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reviews": {
+      "name": "reviews",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "business_id": {
+          "name": "business_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reviewer_name": {
+          "name": "reviewer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reviewer_location": {
+          "name": "reviewer_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "posted_at_raw": {
+          "name": "posted_at_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "posted_at_iso": {
+          "name": "posted_at_iso",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "review_text": {
+          "name": "review_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fetched_at_iso": {
+          "name": "fetched_at_iso",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reviews_biz_user_date": {
+          "name": "reviews_biz_user_date",
+          "columns": [
+            "business_id",
+            "user_id",
+            "posted_at_iso"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "reviews_business_id_businesses_id_fk": {
+          "name": "reviews_business_id_businesses_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "businesses",
+          "columnsFrom": [
+            "business_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1775660295283,
       "tag": "0001_white_dracula",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1775894400000,
+      "tag": "0002_replace_review_url_with_user_id",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1775894400000,
       "tag": "0002_replace_review_url_with_user_id",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1775980800000,
+      "tag": "0003_drop_location_name",
+      "breakpoints": true
     }
   ]
 }

--- a/src/commands/fetch.ts
+++ b/src/commands/fetch.ts
@@ -1,0 +1,56 @@
+import { defineCommand } from "citty";
+import { eq } from "drizzle-orm";
+import { homedir } from "os";
+import { join } from "path";
+import { getDatabase } from "../db";
+import { businesses } from "../db/schema";
+import { getConfig } from "../services/config";
+import { syncReviews } from "../services/review";
+import { scrapeReviews } from "../services/scraper";
+
+function getDb() {
+  return getDatabase(join(homedir(), ".kiwiberry"));
+}
+
+export default defineCommand({
+  meta: { description: "Fetch new Yelp reviews for a business" },
+  args: {
+    b: { type: "string", description: "Business ID", required: true },
+    pages: { type: "string", description: "Number of pages to scrape", required: false }
+  },
+  run({ args }) {
+    const db = getDb();
+
+    const id = Number(args.b);
+    if (Number.isNaN(id)) {
+      console.error("Business ID must be a number");
+      process.exit(1);
+    }
+
+    const biz = db.select().from(businesses).where(eq(businesses.id, id)).get();
+    if (!biz) {
+      console.error(`Business not found: ${id}`);
+      process.exit(1);
+    }
+
+    let maxPages: number;
+    if (args.pages) {
+      maxPages = Number(args.pages);
+      if (Number.isNaN(maxPages) || maxPages < 1) {
+        console.error("--pages must be a positive number");
+        process.exit(1);
+      }
+    } else {
+      maxPages = Number(getConfig(db, "max-pages"));
+    }
+
+    try {
+      const scraped = scrapeReviews(biz.yelpUrl, maxPages);
+      const newReviews = syncReviews(db, biz.id, scraped);
+      console.log(JSON.stringify(newReviews));
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }
+  }
+});

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -22,8 +22,7 @@ export const reviews = sqliteTable("reviews", {
   postedAtRaw: text("posted_at_raw").notNull(),
   postedAtIso: text("posted_at_iso").notNull(),
   reviewText: text("review_text").notNull(),
-  fetchedAtIso: text("fetched_at_iso").notNull(),
-  locationName: text("location_name")
+  fetchedAtIso: text("fetched_at_iso").notNull()
 }, (table) => [
   uniqueIndex("reviews_biz_user_date").on(table.businessId, table.userId, table.postedAtIso)
 ]);

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { sqliteTable, text, integer, real } from "drizzle-orm/sqlite-core";
+import { sqliteTable, text, integer, real, uniqueIndex } from "drizzle-orm/sqlite-core";
 import { sql } from "drizzle-orm";
 
 export const businesses = sqliteTable("businesses", {
@@ -15,16 +15,18 @@ export const reviews = sqliteTable("reviews", {
   businessId: integer("business_id")
     .notNull()
     .references(() => businesses.id, { onDelete: "cascade" }),
+  userId: text("user_id").notNull(),
   reviewerName: text("reviewer_name").notNull(),
   reviewerLocation: text("reviewer_location"),
   rating: real("rating").notNull(),
   postedAtRaw: text("posted_at_raw").notNull(),
-  postedAtIso: text("posted_at_iso"),
+  postedAtIso: text("posted_at_iso").notNull(),
   reviewText: text("review_text").notNull(),
-  reviewUrl: text("review_url").notNull().unique(),
   fetchedAtIso: text("fetched_at_iso").notNull(),
   locationName: text("location_name")
-});
+}, (table) => [
+  uniqueIndex("reviews_biz_user_date").on(table.businessId, table.userId, table.postedAtIso)
+]);
 
 export const draftResponses = sqliteTable("draft_responses", {
   id: integer("id").primaryKey({ autoIncrement: true }),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { defineCommand, renderUsage, runMain } from "citty";
 import business from "./commands/business";
 import config from "./commands/config";
+import fetch from "./commands/fetch";
 
 const main = defineCommand({
   meta: {
@@ -8,7 +9,7 @@ const main = defineCommand({
     version: "0.1.0",
     description: "Yelp review tracker CLI — scrape reviews, draft responses, stay on top of feedback."
   },
-  subCommands: { business, config }
+  subCommands: { business, config, fetch }
 });
 
 void runMain(main, {

--- a/src/services/review.ts
+++ b/src/services/review.ts
@@ -14,8 +14,7 @@ const scrapedReviewSchema = z.object({
   postedAtRaw: z.string().min(1),
   postedAtIso: z.string().min(1),
   reviewText: z.string().min(1),
-  fetchedAtIso: z.string().min(1),
-  locationName: z.string().nullable().optional()
+  fetchedAtIso: z.string().min(1)
 });
 
 export type ScrapedReview = z.infer<typeof scrapedReviewSchema>;
@@ -53,8 +52,7 @@ export function syncReviews(db: Db, businessId: number, scrapedReviews: ScrapedR
       postedAtRaw: r.postedAtRaw,
       postedAtIso: r.postedAtIso,
       reviewText: r.reviewText,
-      fetchedAtIso: r.fetchedAtIso,
-      locationName: r.locationName ?? null
+      fetchedAtIso: r.fetchedAtIso
     }))
   ).returning().all();
 }

--- a/src/services/review.ts
+++ b/src/services/review.ts
@@ -1,0 +1,58 @@
+import { eq } from "drizzle-orm";
+import type { BunSQLiteDatabase } from "drizzle-orm/bun-sqlite";
+import { z } from "zod";
+import { reviews, businesses } from "../db/schema";
+import type * as schema from "../db/schema";
+
+type Db = BunSQLiteDatabase<typeof schema>;
+
+const scrapedReviewSchema = z.object({
+  userId: z.string().min(1),
+  reviewerName: z.string().min(1),
+  reviewerLocation: z.string().nullable().optional(),
+  rating: z.number().min(1).max(5),
+  postedAtRaw: z.string().min(1),
+  postedAtIso: z.string().min(1),
+  reviewText: z.string().min(1),
+  fetchedAtIso: z.string().min(1),
+  locationName: z.string().nullable().optional()
+});
+
+export type ScrapedReview = z.infer<typeof scrapedReviewSchema>;
+
+export function syncReviews(db: Db, businessId: number, scrapedReviews: ScrapedReview[]) {
+  const biz = db.select().from(businesses).where(eq(businesses.id, businessId)).get();
+  if (!biz) throw new Error(`Business not found: ${businessId}`);
+
+  const existing = db
+    .select({ userId: reviews.userId, postedAtIso: reviews.postedAtIso })
+    .from(reviews)
+    .where(eq(reviews.businessId, businessId))
+    .all();
+  const existingKeys = new Set(existing.map(r => `${r.userId}:${r.postedAtIso}`));
+
+  const newReviews: ScrapedReview[] = [];
+  for (const raw of scrapedReviews) {
+    const parsed = scrapedReviewSchema.parse(raw);
+    if (!existingKeys.has(`${parsed.userId}:${parsed.postedAtIso}`)) {
+      newReviews.push(parsed);
+    }
+  }
+
+  if (newReviews.length === 0) return [];
+
+  return db.insert(reviews).values(
+    newReviews.map(r => ({
+      businessId,
+      userId: r.userId,
+      reviewerName: r.reviewerName,
+      reviewerLocation: r.reviewerLocation ?? null,
+      rating: r.rating,
+      postedAtRaw: r.postedAtRaw,
+      postedAtIso: r.postedAtIso,
+      reviewText: r.reviewText,
+      fetchedAtIso: r.fetchedAtIso,
+      locationName: r.locationName ?? null
+    }))
+  ).returning().all();
+}

--- a/src/services/review.ts
+++ b/src/services/review.ts
@@ -34,7 +34,9 @@ export function syncReviews(db: Db, businessId: number, scrapedReviews: ScrapedR
   const newReviews: ScrapedReview[] = [];
   for (const raw of scrapedReviews) {
     const parsed = scrapedReviewSchema.parse(raw);
-    if (!existingKeys.has(`${parsed.userId}:${parsed.postedAtIso}`)) {
+    const key = `${parsed.userId}:${parsed.postedAtIso}`;
+    if (!existingKeys.has(key)) {
+      existingKeys.add(key);
       newReviews.push(parsed);
     }
   }

--- a/src/services/scraper.ts
+++ b/src/services/scraper.ts
@@ -92,22 +92,28 @@ export function scrapeReviews(yelpUrl: string, maxPages: number): ScrapedReview[
 
   const allReviews: ScrapedReview[] = [];
 
-  for (let page = 0; page < maxPages; page++) {
-    if (page > 0) {
-      try {
-        const snapshot = ocBrowser(["snapshot"]);
-        const nextMatch = /link "Next" \[ref=(\w+)\]/.exec(snapshot);
-        if (!nextMatch) break;
-        ocBrowser(["click", nextMatch[1]]);
-        ocBrowser(["wait", "--time", "3000"], 10_000);
-      } catch {
-        break;
+  try {
+    for (let page = 0; page < maxPages; page++) {
+      if (page > 0) {
+        try {
+          const snapshot = ocBrowser(["snapshot"]);
+          const nextMatch = /link "Next" \[ref=(\w+)\]/.exec(snapshot);
+          if (!nextMatch) break;
+          ocBrowser(["click", nextMatch[1]]);
+          ocBrowser(["wait", "--time", "3000"], 10_000);
+        } catch {
+          break;
+        }
       }
-    }
 
-    const snapshot = ocBrowser(["snapshot"]);
-    const pageReviews = parseReviewsFromSnapshot(snapshot);
-    allReviews.push(...pageReviews);
+      const snapshot = ocBrowser(["snapshot"]);
+      const pageReviews = parseReviewsFromSnapshot(snapshot);
+      allReviews.push(...pageReviews);
+    }
+  } finally {
+    try {
+      ocBrowser(["close"]);
+    } catch { /* browser may already be closed */ }
   }
 
   return allReviews;

--- a/src/services/scraper.ts
+++ b/src/services/scraper.ts
@@ -74,8 +74,7 @@ function parseReviewsFromSnapshot(snapshot: string): ScrapedReview[] {
       postedAtRaw,
       postedAtIso,
       reviewText,
-      fetchedAtIso: now,
-      locationName: null
+      fetchedAtIso: now
     });
   }
 

--- a/src/services/scraper.ts
+++ b/src/services/scraper.ts
@@ -87,27 +87,21 @@ export function scrapeReviews(yelpUrl: string, maxPages: number): ScrapedReview[
 
   const allReviews: ScrapedReview[] = [];
 
-  try {
-    ocBrowser(["navigate", sortedUrl], 30_000);
-    ocBrowser(["wait", "--text", "Recommended Reviews", "--timeout-ms", "15000"], 20_000);
+  ocBrowser(["navigate", sortedUrl], 30_000);
+  ocBrowser(["wait", "--text", "Recommended Reviews", "--timeout-ms", "15000"], 20_000);
 
-    for (let page = 0; page < maxPages; page++) {
-      if (page > 0) {
-        const navSnapshot = ocBrowser(["snapshot"]);
-        const nextMatch = /link "Next" \[ref=(\w+)\]/.exec(navSnapshot);
-        if (!nextMatch) break;
-        ocBrowser(["click", nextMatch[1]]);
-        ocBrowser(["wait", "--time", "3000"], 10_000);
-      }
-
-      const snapshot = ocBrowser(["snapshot"]);
-      const pageReviews = parseReviewsFromSnapshot(snapshot);
-      allReviews.push(...pageReviews);
+  for (let page = 0; page < maxPages; page++) {
+    if (page > 0) {
+      const navSnapshot = ocBrowser(["snapshot"]);
+      const nextMatch = /link "Next" \[ref=(\w+)\]/.exec(navSnapshot);
+      if (!nextMatch) break;
+      ocBrowser(["click", nextMatch[1]]);
+      ocBrowser(["wait", "--time", "3000"], 10_000);
     }
-  } finally {
-    try {
-      ocBrowser(["close"]);
-    } catch { /* browser may already be closed */ }
+
+    const snapshot = ocBrowser(["snapshot"]);
+    const pageReviews = parseReviewsFromSnapshot(snapshot);
+    allReviews.push(...pageReviews);
   }
 
   return allReviews;

--- a/src/services/scraper.ts
+++ b/src/services/scraper.ts
@@ -19,7 +19,7 @@ function checkOpenclawInstalled(): void {
   }
 }
 
-function parseReviewsFromSnapshot(snapshot: string): ScrapedReview[] {
+export function parseReviewsFromSnapshot(snapshot: string): ScrapedReview[] {
   const reviews: ScrapedReview[] = [];
   const now = new Date().toISOString();
 
@@ -30,8 +30,7 @@ function parseReviewsFromSnapshot(snapshot: string): ScrapedReview[] {
   for (const match of matches) {
     const reviewerName = match[1];
     // Skip non-reviewer regions
-    if (reviewerName === "Username") continue;
-    if (!(/\.$/.exec(reviewerName)) && !(/\.\.$/.exec(reviewerName))) continue;
+    if (!reviewerName.endsWith(".")) continue;
 
     const startIdx = match.index;
     // Bound the block by the next listitem
@@ -52,7 +51,7 @@ function parseReviewsFromSnapshot(snapshot: string): ScrapedReview[] {
     // Extract rating
     const ratingMatch = /img "(\d+) star rating"/.exec(block);
     const rating = ratingMatch ? parseInt(ratingMatch[1]) : null;
-    if (!rating) continue;
+    if (rating === null) continue;
 
     // Extract date
     const dateMatch = /- generic \[ref=\w+\]: ((?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{1,2}, \d{4})/.exec(block);
@@ -86,23 +85,19 @@ export function scrapeReviews(yelpUrl: string, maxPages: number): ScrapedReview[
 
   const sortedUrl = `${yelpUrl.split("?")[0]}?sort_by=date_desc`;
 
-  ocBrowser(["navigate", sortedUrl], 30_000);
-  ocBrowser(["wait", "--text", "Recommended Reviews", "--timeout-ms", "15000"], 20_000);
-
   const allReviews: ScrapedReview[] = [];
 
   try {
+    ocBrowser(["navigate", sortedUrl], 30_000);
+    ocBrowser(["wait", "--text", "Recommended Reviews", "--timeout-ms", "15000"], 20_000);
+
     for (let page = 0; page < maxPages; page++) {
       if (page > 0) {
-        try {
-          const snapshot = ocBrowser(["snapshot"]);
-          const nextMatch = /link "Next" \[ref=(\w+)\]/.exec(snapshot);
-          if (!nextMatch) break;
-          ocBrowser(["click", nextMatch[1]]);
-          ocBrowser(["wait", "--time", "3000"], 10_000);
-        } catch {
-          break;
-        }
+        const navSnapshot = ocBrowser(["snapshot"]);
+        const nextMatch = /link "Next" \[ref=(\w+)\]/.exec(navSnapshot);
+        if (!nextMatch) break;
+        ocBrowser(["click", nextMatch[1]]);
+        ocBrowser(["wait", "--time", "3000"], 10_000);
       }
 
       const snapshot = ocBrowser(["snapshot"]);

--- a/src/services/scraper.ts
+++ b/src/services/scraper.ts
@@ -1,0 +1,114 @@
+import { execFileSync } from "child_process";
+import type { ScrapedReview } from "./review";
+
+function ocBrowser(args: string[], timeoutMs = 30_000): string {
+  return execFileSync("openclaw", ["browser", ...args], {
+    timeout: timeoutMs,
+    encoding: "utf-8",
+    stdio: ["pipe", "pipe", "pipe"]
+  });
+}
+
+function checkOpenclawInstalled(): void {
+  try {
+    execFileSync("which", ["openclaw"], { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] });
+  } catch {
+    throw new Error(
+      "openclaw CLI is not installed. Install it from https://docs.openclaw.ai to use the fetch command."
+    );
+  }
+}
+
+function parseReviewsFromSnapshot(snapshot: string): ScrapedReview[] {
+  const reviews: ScrapedReview[] = [];
+  const now = new Date().toISOString();
+
+  // Split snapshot into review blocks by looking for region elements with reviewer names
+  const regionPattern = /- region "([^"]+)" \[ref=\w+\]:/g;
+  const matches = [...snapshot.matchAll(regionPattern)];
+
+  for (const match of matches) {
+    const reviewerName = match[1];
+    // Skip non-reviewer regions
+    if (reviewerName === "Username") continue;
+    if (!(/\.$/.exec(reviewerName)) && !(/\.\.$/.exec(reviewerName))) continue;
+
+    const startIdx = match.index;
+    // Bound the block by the next listitem
+    const nextListitem = snapshot.indexOf("- listitem", startIdx + 10);
+    const block = nextListitem > 0
+      ? snapshot.substring(startIdx, nextListitem)
+      : snapshot.substring(startIdx);
+
+    // Extract userId from /url: /user_details?userid=...
+    const userIdMatch = /\/user_details\?userid=(\w+)/.exec(block);
+    const userId = userIdMatch?.[1];
+    if (!userId) continue;
+
+    // Extract location
+    const locationMatch = /- generic \[ref=\w+\]: ([A-Z][^"\n]+(?:,\s*[A-Z]{2}))/.exec(block);
+    const reviewerLocation = locationMatch?.[1] ?? null;
+
+    // Extract rating
+    const ratingMatch = /img "(\d+) star rating"/.exec(block);
+    const rating = ratingMatch ? parseInt(ratingMatch[1]) : null;
+    if (!rating) continue;
+
+    // Extract date
+    const dateMatch = /- generic \[ref=\w+\]: ((?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{1,2}, \d{4})/.exec(block);
+    const postedAtRaw = dateMatch?.[1] ?? null;
+    if (!postedAtRaw) continue;
+
+    const postedAtIso = new Date(postedAtRaw).toISOString().split("T")[0];
+
+    // Extract review text
+    const textMatch = /- paragraph \[ref=\w+\]: (.+)/.exec(block);
+    const reviewText = textMatch?.[1]?.trim();
+    if (!reviewText) continue;
+
+    reviews.push({
+      userId,
+      reviewerName,
+      reviewerLocation,
+      rating,
+      postedAtRaw,
+      postedAtIso,
+      reviewText,
+      fetchedAtIso: now,
+      locationName: null
+    });
+  }
+
+  return reviews;
+}
+
+export function scrapeReviews(yelpUrl: string, maxPages: number): ScrapedReview[] {
+  checkOpenclawInstalled();
+
+  const sortedUrl = `${yelpUrl.split("?")[0]}?sort_by=date_desc`;
+
+  ocBrowser(["navigate", sortedUrl], 30_000);
+  ocBrowser(["wait", "--text", "Recommended Reviews", "--timeout-ms", "15000"], 20_000);
+
+  const allReviews: ScrapedReview[] = [];
+
+  for (let page = 0; page < maxPages; page++) {
+    if (page > 0) {
+      try {
+        const snapshot = ocBrowser(["snapshot"]);
+        const nextMatch = /link "Next" \[ref=(\w+)\]/.exec(snapshot);
+        if (!nextMatch) break;
+        ocBrowser(["click", nextMatch[1]]);
+        ocBrowser(["wait", "--time", "3000"], 10_000);
+      } catch {
+        break;
+      }
+    }
+
+    const snapshot = ocBrowser(["snapshot"]);
+    const pageReviews = parseReviewsFromSnapshot(snapshot);
+    allReviews.push(...pageReviews);
+  }
+
+  return allReviews;
+}

--- a/src/services/scraper.ts
+++ b/src/services/scraper.ts
@@ -41,7 +41,7 @@ function parseReviewsFromSnapshot(snapshot: string): ScrapedReview[] {
       : snapshot.substring(startIdx);
 
     // Extract userId from /url: /user_details?userid=...
-    const userIdMatch = /\/user_details\?userid=(\w+)/.exec(block);
+    const userIdMatch = /\/user_details\?userid=([\w-]+)/.exec(block);
     const userId = userIdMatch?.[1];
     if (!userId) continue;
 

--- a/src/services/scraper.ts
+++ b/src/services/scraper.ts
@@ -19,6 +19,35 @@ function checkOpenclawInstalled(): void {
   }
 }
 
+// openclaw prints plugin banners on stdout before JSON output. Strip any
+// non-JSON prefix so JSON.parse can succeed.
+function stripNonJsonPrefix(output: string): string {
+  const firstBrace = output.indexOf("{");
+  return firstBrace >= 0 ? output.substring(firstBrace) : output;
+}
+
+export function extractTargetId(jsonOutput: string): string | null {
+  try {
+    const parsed = JSON.parse(stripNonJsonPrefix(jsonOutput)) as { targetId?: unknown };
+    return typeof parsed.targetId === "string" ? parsed.targetId : null;
+  } catch {
+    return null;
+  }
+}
+
+export function extractTabIds(jsonOutput: string): string[] {
+  try {
+    const parsed = JSON.parse(stripNonJsonPrefix(jsonOutput)) as { tabs?: unknown };
+    if (!Array.isArray(parsed.tabs)) return [];
+    return parsed.tabs
+      .filter((t): t is { targetId: string } =>
+        typeof t === "object" && t !== null && typeof (t as { targetId?: unknown }).targetId === "string")
+      .map(t => t.targetId);
+  } catch {
+    return [];
+  }
+}
+
 export function findNextPageRef(snapshot: string): string | null {
   // Match: link "Next" [optional modifiers like [active]] [ref=xxx]
   const match = /link "Next"(?:\s\[\w+\])*\s\[ref=(\w+)\]/.exec(snapshot);
@@ -93,21 +122,40 @@ export function scrapeReviews(yelpUrl: string, maxPages: number): ScrapedReview[
 
   const allReviews: ScrapedReview[] = [];
 
-  ocBrowser(["navigate", sortedUrl], 30_000);
-  ocBrowser(["wait", "--text", "Recommended Reviews", "--timeout-ms", "15000"], 20_000);
+  // Record tabs that already existed so we can close only the ones we add.
+  const tabsBefore = new Set(extractTabIds(ocBrowser(["--json", "tabs"])));
+  const openedTabIds: string[] = [];
 
-  for (let page = 0; page < maxPages; page++) {
-    if (page > 0) {
-      const navSnapshot = ocBrowser(["snapshot"]);
-      const nextRef = findNextPageRef(navSnapshot);
-      if (!nextRef) break;
-      ocBrowser(["click", nextRef]);
-      ocBrowser(["wait", "--time", "3000"], 10_000);
+  try {
+    ocBrowser(["open", sortedUrl], 30_000);
+
+    // Diff to find the tab(s) we just added.
+    const tabsAfter = extractTabIds(ocBrowser(["--json", "tabs"]));
+    for (const id of tabsAfter) {
+      if (!tabsBefore.has(id)) openedTabIds.push(id);
     }
 
-    const snapshot = ocBrowser(["snapshot"]);
-    const pageReviews = parseReviewsFromSnapshot(snapshot);
-    allReviews.push(...pageReviews);
+    ocBrowser(["wait", "--text", "Recommended Reviews", "--timeout-ms", "15000"], 20_000);
+
+    for (let page = 0; page < maxPages; page++) {
+      if (page > 0) {
+        const navSnapshot = ocBrowser(["snapshot"]);
+        const nextRef = findNextPageRef(navSnapshot);
+        if (!nextRef) break;
+        ocBrowser(["click", nextRef]);
+        ocBrowser(["wait", "--time", "3000"], 10_000);
+      }
+
+      const snapshot = ocBrowser(["snapshot"]);
+      const pageReviews = parseReviewsFromSnapshot(snapshot);
+      allReviews.push(...pageReviews);
+    }
+  } finally {
+    for (const tabId of openedTabIds) {
+      try {
+        ocBrowser(["close", tabId]);
+      } catch { /* tab may already be gone */ }
+    }
   }
 
   return allReviews;

--- a/src/services/scraper.ts
+++ b/src/services/scraper.ts
@@ -19,6 +19,12 @@ function checkOpenclawInstalled(): void {
   }
 }
 
+export function findNextPageRef(snapshot: string): string | null {
+  // Match: link "Next" [optional modifiers like [active]] [ref=xxx]
+  const match = /link "Next"(?:\s\[\w+\])*\s\[ref=(\w+)\]/.exec(snapshot);
+  return match?.[1] ?? null;
+}
+
 export function parseReviewsFromSnapshot(snapshot: string): ScrapedReview[] {
   const reviews: ScrapedReview[] = [];
   const now = new Date().toISOString();
@@ -93,9 +99,9 @@ export function scrapeReviews(yelpUrl: string, maxPages: number): ScrapedReview[
   for (let page = 0; page < maxPages; page++) {
     if (page > 0) {
       const navSnapshot = ocBrowser(["snapshot"]);
-      const nextMatch = /link "Next" \[ref=(\w+)\]/.exec(navSnapshot);
-      if (!nextMatch) break;
-      ocBrowser(["click", nextMatch[1]]);
+      const nextRef = findNextPageRef(navSnapshot);
+      if (!nextRef) break;
+      ocBrowser(["click", nextRef]);
       ocBrowser(["wait", "--time", "3000"], 10_000);
     }
 

--- a/test/business.test.ts
+++ b/test/business.test.ts
@@ -74,11 +74,12 @@ describe("BusinessService", () => {
 
     db.insert(reviews).values({
       businessId: biz.id,
+      userId: "xyz789",
       reviewerName: "Bob",
       rating: 3,
       postedAtRaw: "Feb 1, 2025",
+      postedAtIso: "2025-02-01",
       reviewText: "Meh",
-      reviewUrl: "https://yelp.com/biz/doomed?hrid=xyz",
       fetchedAtIso: new Date().toISOString()
     }).run();
     const [review] = db.select().from(reviews).all();

--- a/test/db.test.ts
+++ b/test/db.test.ts
@@ -42,11 +42,12 @@ describe("getDatabase", () => {
 
     db.insert(reviews).values({
       businessId: biz.id,
+      userId: "abc123",
       reviewerName: "Alice",
       rating: 5,
       postedAtRaw: "Jan 1, 2025",
+      postedAtIso: "2025-01-01",
       reviewText: "Great!",
-      reviewUrl: "https://yelp.com/biz/test?hrid=abc",
       fetchedAtIso: new Date().toISOString()
     }).run();
     const [review] = db.select().from(reviews).all();
@@ -90,11 +91,12 @@ describe("getDatabase", () => {
 
     db.insert(reviews).values({
       businessId: biz.id,
+      userId: "xyz789",
       reviewerName: "Bob",
       rating: 3,
       postedAtRaw: "Feb 1, 2025",
+      postedAtIso: "2025-02-01",
       reviewText: "Meh",
-      reviewUrl: "https://yelp.com/biz/doomed?hrid=xyz",
       fetchedAtIso: new Date().toISOString()
     }).run();
     const [review] = db.select().from(reviews).all();

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -1,0 +1,89 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import { rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { getDatabase } from "../src/db";
+import { addBusiness } from "../src/services/business";
+import { syncReviews } from "../src/services/review";
+
+function makeTempDir(): string {
+  return join(tmpdir(), `kiwiberry-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+}
+
+function makeReview(overrides: Partial<Parameters<typeof syncReviews>[2][number]> = {}) {
+  return {
+    userId: "abc123",
+    reviewerName: "Alice B.",
+    reviewerLocation: "Temple City, CA",
+    rating: 5,
+    postedAtRaw: "Apr 1, 2026",
+    postedAtIso: "2026-04-01",
+    reviewText: "Amazing shaved ice!",
+    fetchedAtIso: new Date().toISOString(),
+    locationName: "Meet Fresh - Temple City",
+    ...overrides
+  };
+}
+
+describe("ReviewService", () => {
+  const tempDirs: string[] = [];
+
+  function setupDb() {
+    const dataDir = makeTempDir();
+    tempDirs.push(dataDir);
+    return getDatabase(dataDir);
+  }
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    tempDirs.length = 0;
+  });
+
+  test("syncReviews inserts new reviews and returns them", () => {
+    const db = setupDb();
+    const biz = addBusiness(db, "Meet Fresh", "https://www.yelp.com/biz/meet-fresh-temple-city");
+    const reviews = [
+      makeReview(),
+      makeReview({
+        userId: "def456",
+        reviewerName: "Bob C.",
+        rating: 4,
+        reviewText: "Pretty good!"
+      })
+    ];
+
+    const inserted = syncReviews(db, biz.id, reviews);
+
+    expect(inserted).toHaveLength(2);
+    expect(inserted[0].reviewerName).toBe("Alice B.");
+    expect(inserted[1].reviewerName).toBe("Bob C.");
+    expect(inserted[0].businessId).toBe(biz.id);
+    expect(inserted[0].id).toBeGreaterThan(0);
+  });
+
+  test("syncReviews deduplicates by businessId + userId + postedAtIso", () => {
+    const db = setupDb();
+    const biz = addBusiness(db, "Meet Fresh", "https://www.yelp.com/biz/meet-fresh-temple-city");
+    const review = makeReview();
+
+    syncReviews(db, biz.id, [review]);
+    const second = syncReviews(db, biz.id, [review]);
+
+    expect(second).toHaveLength(0);
+  });
+
+  test("syncReviews rejects invalid review data", () => {
+    const db = setupDb();
+    const biz = addBusiness(db, "Meet Fresh", "https://www.yelp.com/biz/meet-fresh-temple-city");
+    const bad = makeReview({ userId: "" });
+
+    expect(() => syncReviews(db, biz.id, [bad])).toThrow();
+  });
+
+  test("syncReviews throws for non-existent business", () => {
+    const db = setupDb();
+    expect(() => syncReviews(db, 999, [makeReview()])).toThrow("Business not found: 999");
+  });
+});

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -82,6 +82,16 @@ describe("ReviewService", () => {
     expect(() => syncReviews(db, biz.id, [bad])).toThrow();
   });
 
+  test("syncReviews deduplicates within the same batch", () => {
+    const db = setupDb();
+    const biz = addBusiness(db, "Meet Fresh", "https://www.yelp.com/biz/meet-fresh-temple-city");
+    const review = makeReview();
+
+    const inserted = syncReviews(db, biz.id, [review, review]);
+
+    expect(inserted).toHaveLength(1);
+  });
+
   test("syncReviews throws for non-existent business", () => {
     const db = setupDb();
     expect(() => syncReviews(db, 999, [makeReview()])).toThrow("Business not found: 999");

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -20,7 +20,6 @@ function makeReview(overrides: Partial<Parameters<typeof syncReviews>[2][number]
     postedAtIso: "2026-04-01",
     reviewText: "Amazing shaved ice!",
     fetchedAtIso: new Date().toISOString(),
-    locationName: "Meet Fresh - Temple City",
     ...overrides
   };
 }

--- a/test/scraper.test.ts
+++ b/test/scraper.test.ts
@@ -1,0 +1,103 @@
+import { describe, test, expect } from "bun:test";
+import { parseReviewsFromSnapshot } from "../src/services/scraper";
+
+const VALID_SNAPSHOT = `
+- list [ref=e1]:
+  - listitem [ref=e2]:
+    - region "Alice B." [ref=e3]:
+      - link [ref=e4]:
+        - /url: /user_details?userid=e--n82PbYbHyFkRWK0I69g
+      - generic [ref=e5]: Temple City, CA
+      - img "5 star rating" [ref=e6]
+      - generic [ref=e7]: Apr 1, 2026
+      - paragraph [ref=e8]: Amazing shaved ice!
+  - listitem [ref=e9]:
+`;
+
+describe("parseReviewsFromSnapshot", () => {
+  test("skips non-reviewer regions", () => {
+    const snapshot = `
+- list [ref=e1]:
+  - listitem [ref=e2]:
+    - region "Username" [ref=e3]:
+      - link [ref=e4]:
+        - /url: /user_details?userid=abc123
+      - img "5 star rating" [ref=e5]
+      - generic [ref=e6]: Apr 1, 2026
+      - paragraph [ref=e7]: Some text
+  - listitem [ref=e8]:
+    - region "Recommended Reviews" [ref=e9]:
+      - paragraph [ref=e10]: Other content
+  - listitem [ref=e11]:
+`;
+    const reviews = parseReviewsFromSnapshot(snapshot);
+    expect(reviews).toHaveLength(0);
+  });
+
+  test("skips review blocks missing required fields", () => {
+    // Missing userId
+    const noUserId = `
+- list [ref=e1]:
+  - listitem [ref=e2]:
+    - region "Bob C." [ref=e3]:
+      - img "4 star rating" [ref=e4]
+      - generic [ref=e5]: Mar 15, 2026
+      - paragraph [ref=e6]: Great place
+  - listitem [ref=e7]:
+`;
+    expect(parseReviewsFromSnapshot(noUserId)).toHaveLength(0);
+
+    // Missing rating
+    const noRating = `
+- list [ref=e1]:
+  - listitem [ref=e2]:
+    - region "Bob C." [ref=e3]:
+      - link [ref=e4]:
+        - /url: /user_details?userid=abc123
+      - generic [ref=e5]: Mar 15, 2026
+      - paragraph [ref=e6]: Great place
+  - listitem [ref=e7]:
+`;
+    expect(parseReviewsFromSnapshot(noRating)).toHaveLength(0);
+
+    // Missing date
+    const noDate = `
+- list [ref=e1]:
+  - listitem [ref=e2]:
+    - region "Bob C." [ref=e3]:
+      - link [ref=e4]:
+        - /url: /user_details?userid=abc123
+      - img "4 star rating" [ref=e5]
+      - paragraph [ref=e6]: Great place
+  - listitem [ref=e7]:
+`;
+    expect(parseReviewsFromSnapshot(noDate)).toHaveLength(0);
+
+    // Missing review text
+    const noText = `
+- list [ref=e1]:
+  - listitem [ref=e2]:
+    - region "Bob C." [ref=e3]:
+      - link [ref=e4]:
+        - /url: /user_details?userid=abc123
+      - img "4 star rating" [ref=e5]
+      - generic [ref=e6]: Mar 15, 2026
+  - listitem [ref=e7]:
+`;
+    expect(parseReviewsFromSnapshot(noText)).toHaveLength(0);
+  });
+
+  test("parses a valid review block into a ScrapedReview", () => {
+    const reviews = parseReviewsFromSnapshot(VALID_SNAPSHOT);
+
+    expect(reviews).toHaveLength(1);
+    expect(reviews[0].userId).toBe("e--n82PbYbHyFkRWK0I69g");
+    expect(reviews[0].reviewerName).toBe("Alice B.");
+    expect(reviews[0].reviewerLocation).toBe("Temple City, CA");
+    expect(reviews[0].rating).toBe(5);
+    expect(reviews[0].postedAtRaw).toBe("Apr 1, 2026");
+    expect(reviews[0].postedAtIso).toBe("2026-04-01");
+    expect(reviews[0].reviewText).toBe("Amazing shaved ice!");
+    expect(reviews[0].fetchedAtIso).toBeDefined();
+  });
+});

--- a/test/scraper.test.ts
+++ b/test/scraper.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { parseReviewsFromSnapshot } from "../src/services/scraper";
+import { parseReviewsFromSnapshot, findNextPageRef } from "../src/services/scraper";
 
 const VALID_SNAPSHOT = `
 - list [ref=e1]:
@@ -13,6 +13,42 @@ const VALID_SNAPSHOT = `
       - paragraph [ref=e8]: Amazing shaved ice!
   - listitem [ref=e9]:
 `;
+
+describe("findNextPageRef", () => {
+  test("finds Next link ref on first page (no modifiers)", () => {
+    const snapshot = `
+- navigation "Pagination navigation":
+  - link "Next" [ref=e5334] [cursor=pointer]:
+    - /url: https://www.yelp.com/biz/meet-fresh-temple-city?start=10
+`;
+    expect(findNextPageRef(snapshot)).toBe("e5334");
+  });
+
+  test("finds Next link ref when it has [active] modifier", () => {
+    const snapshot = `
+- navigation "Pagination navigation":
+  - link "Next" [active] [ref=e2169] [cursor=pointer]:
+    - /url: https://www.yelp.com/biz/meet-fresh-temple-city?start=20
+`;
+    expect(findNextPageRef(snapshot)).toBe("e2169");
+  });
+
+  test("returns null when no Next link exists", () => {
+    const snapshot = `
+- navigation "Pagination navigation":
+  - link "Previous" [ref=e1234] [cursor=pointer]
+`;
+    expect(findNextPageRef(snapshot)).toBeNull();
+  });
+
+  test("ignores button 'Next' (e.g. photo gallery)", () => {
+    const snapshot = `
+- button "Next" [ref=e147] [cursor=pointer]:
+  - img [ref=e149]
+`;
+    expect(findNextPageRef(snapshot)).toBeNull();
+  });
+});
 
 describe("parseReviewsFromSnapshot", () => {
   test("skips non-reviewer regions", () => {

--- a/test/scraper.test.ts
+++ b/test/scraper.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { parseReviewsFromSnapshot, findNextPageRef } from "../src/services/scraper";
+import { parseReviewsFromSnapshot, findNextPageRef, extractTargetId, extractTabIds } from "../src/services/scraper";
 
 const VALID_SNAPSHOT = `
 - list [ref=e1]:
@@ -13,6 +13,69 @@ const VALID_SNAPSHOT = `
       - paragraph [ref=e8]: Amazing shaved ice!
   - listitem [ref=e9]:
 `;
+
+describe("extractTabIds", () => {
+  test("extracts all tab targetIds from openclaw tabs JSON output", () => {
+    const output = `{
+  "tabs": [
+    { "targetId": "AAA111", "title": "Blank", "url": "about:blank", "type": "page" },
+    { "targetId": "BBB222", "title": "Yelp", "url": "https://yelp.com", "type": "page" }
+  ]
+}`;
+    expect(extractTabIds(output)).toEqual(["AAA111", "BBB222"]);
+  });
+
+  test("returns empty array when no tabs", () => {
+    expect(extractTabIds("{\"tabs\": []}")).toEqual([]);
+  });
+
+  test("returns empty array for invalid JSON", () => {
+    expect(extractTabIds("not json")).toEqual([]);
+  });
+
+  test("strips non-JSON plugin output prefix before parsing", () => {
+    const output = `[plugins] memory-lancedb-pro: smart extraction enabled
+[plugins] mdMirror: resolved 2 agent workspace(s)
+{
+  "tabs": [
+    { "targetId": "AAA111", "title": "Yelp", "url": "https://yelp.com", "type": "page" }
+  ]
+}`;
+    expect(extractTabIds(output)).toEqual(["AAA111"]);
+  });
+});
+
+describe("extractTargetId", () => {
+  test("extracts targetId from openclaw open JSON output", () => {
+    const output = `{
+  "targetId": "650CD55DB4290A3379C83D3238AD8C6E",
+  "title": "",
+  "url": "about:blank",
+  "type": "page"
+}`;
+    expect(extractTargetId(output)).toBe("650CD55DB4290A3379C83D3238AD8C6E");
+  });
+
+  test("returns null when output has no targetId", () => {
+    expect(extractTargetId("{}")).toBeNull();
+  });
+
+  test("returns null for invalid JSON", () => {
+    expect(extractTargetId("not json")).toBeNull();
+  });
+
+  test("strips non-JSON plugin output prefix before parsing", () => {
+    const output = `[plugins] memory-lancedb-pro: smart extraction enabled
+[plugins] hook runner initialized with 1 registered hooks
+{
+  "targetId": "650CD55DB4290A3379C83D3238AD8C6E",
+  "title": "",
+  "url": "about:blank",
+  "type": "page"
+}`;
+    expect(extractTargetId(output)).toBe("650CD55DB4290A3379C83D3238AD8C6E");
+  });
+});
 
 describe("findNextPageRef", () => {
   test("finds Next link ref on first page (no modifiers)", () => {


### PR DESCRIPTION
## Summary

- Add `fetch -b <id> [--pages N]` CLI command to scrape Yelp reviews via openclaw browser CLI
- Review service with Zod validation and dedup by `businessId + userId + postedAtIso` composite unique index
- Scraper parses openclaw AI snapshots, paginates, sorts Newest First
- Schema migration: replace `review_url` with `user_id`, add composite unique index
- 5 review service tests (insert, cross-run dedup, in-batch dedup, validation, missing business)
- Updated architecture.md and testing.md

Closes #5

## Test plan

- [x] `bun test` — all 21 tests pass
- [x] `bun run lint` — clean
- [x] Smoke test: `bun run dev business add "Meet Fresh" "https://www.yelp.com/biz/meet-fresh-temple-city"`
- [x] Smoke test: `bun run dev fetch -b 1 --pages 1` returns reviews as JSON
- [x] Smoke test: re-running `fetch -b 1 --pages 1` returns `[]` (dedup)
- [x] Smoke test: `bun run dev fetch -b 999` errors with "Business not found"

🤖 Generated with [Claude Code](https://claude.com/claude-code)