### PR TITLE
Add reviews list command (closes #6)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,6 +9,7 @@ src/
     business.ts       — business add/list/remove subcommands
     config.ts         — config get/set subcommands
     fetch.ts          — fetch reviews for a business
+    reviews.ts        — list stored reviews for a business
   db/
     schema.ts         — Drizzle ORM schema (4 tables)
     index.ts          — getDatabase(dataDir) auto-init + migrations
@@ -83,12 +84,13 @@ getConfig(db, key)         // → string; returns DB value, then default, or thr
 
 ```typescript
 syncReviews(db, businessId, scrapedReviews[])  // → newly inserted review rows
+listReviews(db, businessId)                    // → all stored reviews for the business
 ```
 
-- Validates each review with Zod (userId, reviewerName, rating 1–5, postedAtRaw, postedAtIso, reviewText, fetchedAtIso required).
-- Deduplicates by composite key: `businessId + userId + postedAtIso`.
-- Dedup covers both existing DB rows and duplicates within the same batch.
-- Throws if `businessId` does not exist.
+- `syncReviews` validates each review with Zod (userId, reviewerName, rating 1–5, postedAtRaw, postedAtIso, reviewText, fetchedAtIso required).
+- `syncReviews` deduplicates by composite key: `businessId + userId + postedAtIso`. Dedup covers both existing DB rows and duplicates within the same batch.
+- `listReviews` returns every stored review row for the business, scoped by `businessId`. Returns `[]` if the business has no reviews.
+- Both functions throw `Business not found: N` if `businessId` does not exist.
 
 ### Scraper (`src/services/scraper.ts`)
 
@@ -145,6 +147,7 @@ Uses citty (unjs/citty). The root command is defined in `src/index.ts`. Commands
 | `config get <key>` | `{"key":"...","value":"..."}` | "Unknown config key: ..." |
 | `config set <key> <value>` | `{"key":"...","value":"..."}` | — |
 | `fetch -b <id> [--pages N]` | JSON array of new reviews | "Business not found" / "openclaw CLI is not installed" |
+| `reviews -b <id>` | JSON array of all stored reviews | "Business not found" / "Business ID must be a number" |
 
 All CLI output goes as JSON on stdout. Human-readable error messages go on stderr.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -55,7 +55,7 @@ Tests exercise `getConfig` and `setConfig`:
 
 ### Review Service (test/review.test.ts)
 
-Tests exercise `syncReviews`:
+Tests exercise `syncReviews` and `listReviews`:
 
 | Test | What It Verifies |
 |---|---|
@@ -64,6 +64,10 @@ Tests exercise `syncReviews`:
 | syncReviews rejects invalid review data | Zod validation: empty userId throws |
 | syncReviews deduplicates within the same batch | Duplicate entries in one call produce only one insert |
 | syncReviews throws for non-existent business | Throws `Business not found: N` for missing ID |
+| listReviews returns all reviews for a business with every field populated | Returns all stored fields: id, businessId, userId, reviewerName, reviewerLocation, rating, postedAtRaw, postedAtIso, reviewText, fetchedAtIso |
+| listReviews returns empty array when business has no reviews | Existing business with no rows returns `[]` |
+| listReviews only returns reviews for the specified business | Rows belonging to other businesses are excluded |
+| listReviews throws for non-existent business | Throws `Business not found: N` for missing ID |
 
 ### Scraper (test/scraper.test.ts)
 

--- a/src/commands/reviews.ts
+++ b/src/commands/reviews.ts
@@ -1,0 +1,33 @@
+import { defineCommand } from "citty";
+import { homedir } from "os";
+import { join } from "path";
+import { getDatabase } from "../db";
+import { listReviews } from "../services/review";
+
+function getDb() {
+  return getDatabase(join(homedir(), ".kiwiberry"));
+}
+
+export default defineCommand({
+  meta: { description: "List all stored reviews for a business" },
+  args: {
+    b: { type: "string", description: "Business ID", required: true }
+  },
+  run({ args }) {
+    const db = getDb();
+
+    const id = Number(args.b);
+    if (Number.isNaN(id)) {
+      console.error("Business ID must be a number");
+      process.exit(1);
+    }
+
+    try {
+      const reviews = listReviews(db, id);
+      console.log(JSON.stringify(reviews));
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }
+  }
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { defineCommand, renderUsage, runMain } from "citty";
 import business from "./commands/business";
 import config from "./commands/config";
 import fetch from "./commands/fetch";
+import reviews from "./commands/reviews";
 
 const main = defineCommand({
   meta: {
@@ -9,7 +10,7 @@ const main = defineCommand({
     version: "0.1.0",
     description: "Yelp review tracker CLI — scrape reviews, draft responses, stay on top of feedback."
   },
-  subCommands: { business, config, fetch }
+  subCommands: { business, config, fetch, reviews }
 });
 
 void runMain(main, {

--- a/src/services/review.ts
+++ b/src/services/review.ts
@@ -19,6 +19,13 @@ const scrapedReviewSchema = z.object({
 
 export type ScrapedReview = z.infer<typeof scrapedReviewSchema>;
 
+export function listReviews(db: Db, businessId: number) {
+  const biz = db.select().from(businesses).where(eq(businesses.id, businessId)).get();
+  if (!biz) throw new Error(`Business not found: ${businessId}`);
+
+  return db.select().from(reviews).where(eq(reviews.businessId, businessId)).all();
+}
+
 export function syncReviews(db: Db, businessId: number, scrapedReviews: ScrapedReview[]) {
   const biz = db.select().from(businesses).where(eq(businesses.id, businessId)).get();
   if (!biz) throw new Error(`Business not found: ${businessId}`);

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -4,7 +4,7 @@ import { join } from "path";
 import { tmpdir } from "os";
 import { getDatabase } from "../src/db";
 import { addBusiness } from "../src/services/business";
-import { syncReviews } from "../src/services/review";
+import { listReviews, syncReviews } from "../src/services/review";
 
 function makeTempDir(): string {
   return join(tmpdir(), `kiwiberry-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
@@ -94,5 +94,50 @@ describe("ReviewService", () => {
   test("syncReviews throws for non-existent business", () => {
     const db = setupDb();
     expect(() => syncReviews(db, 999, [makeReview()])).toThrow("Business not found: 999");
+  });
+
+  test("listReviews throws for non-existent business", () => {
+    const db = setupDb();
+    expect(() => listReviews(db, 999)).toThrow("Business not found: 999");
+  });
+
+  test("listReviews only returns reviews for the specified business", () => {
+    const db = setupDb();
+    const bizA = addBusiness(db, "Meet Fresh", "https://www.yelp.com/biz/meet-fresh-temple-city");
+    const bizB = addBusiness(db, "Other Shop", "https://www.yelp.com/biz/other-shop");
+
+    syncReviews(db, bizA.id, [makeReview({ userId: "alice" })]);
+    syncReviews(db, bizB.id, [makeReview({ userId: "bob" })]);
+
+    const listed = listReviews(db, bizA.id);
+    expect(listed).toHaveLength(1);
+    expect(listed[0].userId).toBe("alice");
+  });
+
+  test("listReviews returns empty array when business has no reviews", () => {
+    const db = setupDb();
+    const biz = addBusiness(db, "Meet Fresh", "https://www.yelp.com/biz/meet-fresh-temple-city");
+
+    expect(listReviews(db, biz.id)).toEqual([]);
+  });
+
+  test("listReviews returns all reviews for a business with every field populated", () => {
+    const db = setupDb();
+    const biz = addBusiness(db, "Meet Fresh", "https://www.yelp.com/biz/meet-fresh-temple-city");
+    syncReviews(db, biz.id, [makeReview()]);
+
+    const listed = listReviews(db, biz.id);
+
+    expect(listed).toHaveLength(1);
+    expect(listed[0].id).toBeGreaterThan(0);
+    expect(listed[0].businessId).toBe(biz.id);
+    expect(listed[0].userId).toBe("abc123");
+    expect(listed[0].reviewerName).toBe("Alice B.");
+    expect(listed[0].reviewerLocation).toBe("Temple City, CA");
+    expect(listed[0].rating).toBe(5);
+    expect(listed[0].postedAtRaw).toBe("Apr 1, 2026");
+    expect(listed[0].postedAtIso).toBe("2026-04-01");
+    expect(listed[0].reviewText).toBe("Amazing shaved ice!");
+    expect(listed[0].fetchedAtIso).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary
- Adds `kiwiberry reviews -b <id>` to list all stored reviews for a business as a JSON array — lets users inspect already-scraped reviews without re-hitting Yelp.
- New `listReviews(db, businessId)` service function scoped by `businessId`; throws `Business not found: N` for unknown IDs (matches `syncReviews` error style).
- Thin CLI wiring in `src/commands/reviews.ts`, mirroring `fetch.ts`.
- Docs (`architecture.md`, `testing.md`) updated to cover the new command, service function, and tests.

## Acceptance criteria (issue #6)
- [x] `reviews -b <id>` returns all reviews for the business as JSON array
- [x] All current review fields included in output (note: `review_url` and `location_name` referenced in the stale issue text were removed by migrations 0002/0003)
- [x] Errors with helpful message if business ID does not exist (`Business not found: N`, exit 1)
- [x] Returns empty array if business has no reviews
- [x] JSON on stdout, messages on stderr

## Test plan
- [x] `bun test` — 40 pass, 0 fail (4 new `listReviews` tests)
- [x] `bun run lint` — clean
- [x] Manual smoke: `reviews -b 1` on fresh business → `[]` on stdout
- [x] Manual smoke: `reviews -b 999` → stderr `Business not found: 999`, exit 1, stdout empty
- [x] Manual smoke: `reviews -b abc` → stderr `Business ID must be a number`, exit 1, stdout empty

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)