### PR TITLE
Bundle migrations into compiled binary (closes #8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,24 @@ bun run dev business add "Shop B" "https://www.yelp.com/biz/shop"
 # stderr: A business with this Yelp URL is already registered
 ```
 
+## Build a standalone binary
+
+Compile Kiwiberry to a single executable that runs without Bun installed:
+
+```bash
+bun run build
+# → dist/kiwiberry
+```
+
+`bun build --compile` bundles the runtime, all dependencies, and every Drizzle migration SQL file into one self-contained binary. Copy `dist/kiwiberry` anywhere on `PATH` and run it directly:
+
+```bash
+./dist/kiwiberry business list
+./dist/kiwiberry config get max-pages
+```
+
+The binary auto-initializes `~/.kiwiberry/` and applies bundled migrations on first run, exactly like `bun run dev`. `fetch` still requires the [OpenClaw](https://openclaw.dev/) browser CLI on the host machine.
+
 ## Data storage
 
 Data is stored in `~/.kiwiberry/kiwiberry.db` (SQLite). The database and directory are created automatically on first use. To start fresh, delete that file.
@@ -97,6 +115,7 @@ bun test                 # Run all tests
 bun test test/db.test.ts # Run a single test file
 bun run lint             # ESLint with strict type-checking
 bun run lint -- --fix    # Auto-fix lint issues
+bun run build            # Compile a standalone binary → dist/kiwiberry
 bunx drizzle-kit generate # Generate migration after schema changes
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,6 +15,8 @@ src/
   db/
     schema.ts         — Drizzle ORM schema (4 tables)
     index.ts          — getDatabase(dataDir) auto-init + migrations
+    migrator.ts       — applyBundledMigrations: statement-breakpoint-aware runner
+    migrations.ts     — drizzle/*.sql imported as text so `bun build --compile` embeds them
   services/
     business.ts       — business CRUD with Zod validation
     config.ts         — config key-value get/set with defaults
@@ -43,7 +45,9 @@ drizzle/
 getDatabase(dataDir: string): BunSQLiteDatabase
 ```
 
-Takes a directory path, creates it if missing, opens SQLite with WAL mode + foreign keys enabled, runs all pending Drizzle migrations, and returns a Drizzle DB instance.
+Takes a directory path, creates it if missing, opens SQLite with WAL mode + foreign keys enabled, runs all pending bundled migrations via `applyBundledMigrations`, and returns a Drizzle DB instance.
+
+Migration SQL files under `drizzle/` are imported as text (`with { type: "text" }`) in `db/migrations.ts`, so `bun build --compile` inlines every statement into the standalone binary — no runtime filesystem lookups against the source tree. The runner tracks applied migrations in a `__kiwiberry_migrations__` table keyed by journal idx, splits each SQL file on `--> statement-breakpoint`, and applies each pending migration inside a transaction.
 
 The production data directory is `~/.kiwiberry/`, with the DB file at `~/.kiwiberry/kiwiberry.db`.
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "bun run src/index.ts",
     "test": "bun test",
     "lint": "eslint .",
+    "build": "bun build --compile --minify --sourcemap src/index.ts --outfile dist/kiwiberry",
     "db:generate": "drizzle-kit generate"
   },
   "dependencies": {

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -2,8 +2,9 @@ import { mkdirSync } from "fs";
 import { join } from "path";
 import { Database } from "bun:sqlite";
 import { drizzle } from "drizzle-orm/bun-sqlite";
-import { migrate } from "drizzle-orm/bun-sqlite/migrator";
 import * as schema from "./schema";
+import { bundledMigrations } from "./migrations";
+import { applyBundledMigrations } from "./migrator";
 
 export function getDatabase(dataDir: string) {
   mkdirSync(dataDir, { recursive: true });
@@ -12,8 +13,7 @@ export function getDatabase(dataDir: string) {
   sqlite.run("PRAGMA journal_mode = WAL;");
   sqlite.run("PRAGMA foreign_keys = ON;");
 
-  const db = drizzle(sqlite, { schema });
-  migrate(db, { migrationsFolder: join(import.meta.dir, "../../drizzle") });
+  applyBundledMigrations(sqlite, bundledMigrations);
 
-  return db;
+  return drizzle(sqlite, { schema });
 }

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -1,0 +1,15 @@
+// Migration SQL is imported as text so `bun build --compile` embeds it into the
+// binary. Keep this list in sync with drizzle/meta/_journal.json when new
+// migrations are generated via `bunx drizzle-kit generate`.
+import migration0000 from "../../drizzle/0000_smart_sheva_callister.sql" with { type: "text" };
+import migration0001 from "../../drizzle/0001_white_dracula.sql" with { type: "text" };
+import migration0002 from "../../drizzle/0002_replace_review_url_with_user_id.sql" with { type: "text" };
+import migration0003 from "../../drizzle/0003_drop_location_name.sql" with { type: "text" };
+import type { BundledMigration } from "./migrator";
+
+export const bundledMigrations: BundledMigration[] = [
+  { idx: 0, tag: "0000_smart_sheva_callister", sql: migration0000 },
+  { idx: 1, tag: "0001_white_dracula", sql: migration0001 },
+  { idx: 2, tag: "0002_replace_review_url_with_user_id", sql: migration0002 },
+  { idx: 3, tag: "0003_drop_location_name", sql: migration0003 }
+];

--- a/src/db/migrator.ts
+++ b/src/db/migrator.ts
@@ -1,0 +1,46 @@
+import type { Database } from "bun:sqlite";
+
+export interface BundledMigration {
+  idx: number;
+  tag: string;
+  sql: string;
+}
+
+const MIGRATIONS_TABLE = "__kiwiberry_migrations__";
+const STATEMENT_BREAKPOINT = /^\s*-->\s*statement-breakpoint\s*$/m;
+
+export function applyBundledMigrations(sqlite: Database, migrations: BundledMigration[]): void {
+  sqlite.run(`
+    CREATE TABLE IF NOT EXISTS ${MIGRATIONS_TABLE} (
+      idx INTEGER PRIMARY KEY,
+      tag TEXT NOT NULL,
+      applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+  `);
+
+  const appliedRows = sqlite
+    .query<{ idx: number }, []>(`SELECT idx FROM ${MIGRATIONS_TABLE}`)
+    .all();
+  const applied = new Set(appliedRows.map((r) => r.idx));
+
+  const pending = migrations
+    .filter((m) => !applied.has(m.idx))
+    .slice()
+    .sort((a, b) => a.idx - b.idx);
+
+  for (const migration of pending) {
+    const statements = migration.sql
+      .split(STATEMENT_BREAKPOINT)
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+
+    sqlite.transaction(() => {
+      for (const stmt of statements) {
+        sqlite.run(stmt);
+      }
+      sqlite
+        .prepare(`INSERT INTO ${MIGRATIONS_TABLE} (idx, tag) VALUES (?, ?)`)
+        .run(migration.idx, migration.tag);
+    })();
+  }
+}

--- a/src/db/sql-text.d.ts
+++ b/src/db/sql-text.d.ts
@@ -1,0 +1,6 @@
+// Bun's `with { type: "text" }` import attribute returns the file contents as
+// a string. TypeScript does not know this by default, so declare it here.
+declare module "*.sql" {
+  const content: string;
+  export default content;
+}

--- a/test/migrator.test.ts
+++ b/test/migrator.test.ts
@@ -1,0 +1,110 @@
+import { describe, test, expect } from "bun:test";
+import { Database } from "bun:sqlite";
+import { applyBundledMigrations, type BundledMigration } from "../src/db/migrator";
+
+function memoryDb(): Database {
+  return new Database(":memory:");
+}
+
+describe("applyBundledMigrations", () => {
+  test("applies a single migration's statements in order", () => {
+    const sqlite = memoryDb();
+    const migrations: BundledMigration[] = [
+      {
+        idx: 0,
+        tag: "0000_init",
+        sql: [
+          "CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT NOT NULL);",
+          "--> statement-breakpoint",
+          "INSERT INTO t (name) VALUES ('seed');"
+        ].join("\n")
+      }
+    ];
+
+    applyBundledMigrations(sqlite, migrations);
+
+    const rows = sqlite.query("SELECT name FROM t").all() as { name: string }[];
+    expect(rows).toEqual([{ name: "seed" }]);
+  });
+
+  test("applies migrations in idx order across multiple entries", () => {
+    const sqlite = memoryDb();
+    const migrations: BundledMigration[] = [
+      { idx: 0, tag: "0000_init", sql: "CREATE TABLE t (id INTEGER PRIMARY KEY);" },
+      { idx: 1, tag: "0001_col", sql: "ALTER TABLE t ADD COLUMN label TEXT;" }
+    ];
+
+    applyBundledMigrations(sqlite, migrations);
+
+    sqlite.run("INSERT INTO t (label) VALUES ('ok');");
+    const rows = sqlite.query("SELECT label FROM t").all() as { label: string }[];
+    expect(rows).toEqual([{ label: "ok" }]);
+  });
+
+  test("is idempotent: rerunning does not reapply already-applied migrations", () => {
+    const sqlite = memoryDb();
+    const migrations: BundledMigration[] = [
+      {
+        idx: 0,
+        tag: "0000_init",
+        sql: "CREATE TABLE t (id INTEGER PRIMARY KEY);"
+      }
+    ];
+
+    applyBundledMigrations(sqlite, migrations);
+    // Re-running with the same migration list must not throw "table t already exists".
+    const rerun = () => {
+      applyBundledMigrations(sqlite, migrations);
+    };
+    expect(rerun).not.toThrow();
+  });
+
+  test("applies only pending migrations when some are already applied", () => {
+    const sqlite = memoryDb();
+    const first: BundledMigration[] = [
+      { idx: 0, tag: "0000_init", sql: "CREATE TABLE t (id INTEGER PRIMARY KEY);" }
+    ];
+    applyBundledMigrations(sqlite, first);
+
+    const both: BundledMigration[] = [
+      ...first,
+      { idx: 1, tag: "0001_col", sql: "ALTER TABLE t ADD COLUMN label TEXT;" }
+    ];
+    applyBundledMigrations(sqlite, both);
+
+    sqlite.run("INSERT INTO t (label) VALUES ('still-works');");
+    const rows = sqlite.query("SELECT label FROM t").all() as { label: string }[];
+    expect(rows).toEqual([{ label: "still-works" }]);
+  });
+
+  test("unsorted input still applies in idx order", () => {
+    const sqlite = memoryDb();
+    const migrations: BundledMigration[] = [
+      { idx: 1, tag: "0001_col", sql: "ALTER TABLE t ADD COLUMN label TEXT;" },
+      { idx: 0, tag: "0000_init", sql: "CREATE TABLE t (id INTEGER PRIMARY KEY);" }
+    ];
+
+    const rerun = () => {
+      applyBundledMigrations(sqlite, migrations);
+    };
+    expect(rerun).not.toThrow();
+    sqlite.run("INSERT INTO t (label) VALUES ('ordered');");
+    const rows = sqlite.query("SELECT label FROM t").all() as { label: string }[];
+    expect(rows).toEqual([{ label: "ordered" }]);
+  });
+
+  test("handles statement-breakpoint markers with surrounding whitespace", () => {
+    const sqlite = memoryDb();
+    const migrations: BundledMigration[] = [
+      {
+        idx: 0,
+        tag: "0000_multi",
+        sql: "CREATE TABLE a (id INTEGER);\n  --> statement-breakpoint  \nCREATE TABLE b (id INTEGER);"
+      }
+    ];
+
+    applyBundledMigrations(sqlite, migrations);
+    expect(() => sqlite.run("INSERT INTO a VALUES (1);")).not.toThrow();
+    expect(() => sqlite.run("INSERT INTO b VALUES (1);")).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `bun run build` → `dist/kiwiberry`, a single self-contained executable
- Bundles every `drizzle/*.sql` into the binary via `with { type: "text" }` imports and runs them through a small in-repo migrator (`applyBundledMigrations`) that tracks applied indices in `__kiwiberry_migrations__` and splits on `--> statement-breakpoint`
- Replaces the filesystem-dependent `drizzle-orm/bun-sqlite/migrator` inside `getDatabase` so the compiled binary no longer needs the `drizzle/` folder at runtime

## Why

`bun build --compile` produces one binary but does not ship the source tree, so `drizzle-orm`'s migrator (which calls `fs.readdirSync` on `migrationsFolder`) would fail on first run from the binary. Embedding the SQL as text bakes every statement into the executable at build time.

## TDD

Started with `test/migrator.test.ts` (6 cases: single migration, multi-migration order, idempotency, pending-only application, unsorted input, breakpoint whitespace) — watched them fail with "Cannot find module '../src/db/migrator'", then implemented the minimal runner to green.

## Test plan

- [x] `bun test` — 55 pass (6 new migrator tests + all existing)
- [x] `bun run lint` — clean
- [x] `bun run build` produces `dist/kiwiberry` (~59 MB, arm64 Mach-O)
- [x] Binary auto-inits `~/.kiwiberry/` on first run (verified with `HOME` override to a temp dir)
- [x] All 4 migrations applied from binary — `sqlite3 .tables` shows `businesses`, `reviews`, `draft_responses`, `config`, `__kiwiberry_migrations__`
- [x] `business add/list/remove` works from binary, cascade delete verified
- [x] `config get/set max-pages` works from binary
- [x] `reviews -b <id>` works from binary
- [x] `respond <id> "text"` inline + stdin piping both work from binary
- [x] `responses <id>` works from binary
- [ ] `fetch` still requires external openclaw CLI (unchanged by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)