### PR TITLE
Sign darwin binaries by building on macos-latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,48 @@ permissions:
   contents: write
 
 jobs:
+  darwin-build:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build darwin targets
+        run: |
+          bun run build:darwin-arm64
+          bun run build:darwin-x64
+
+      - name: Verify darwin binaries are signed
+        run: |
+          set -euo pipefail
+          for target in darwin-arm64 darwin-x64; do
+            bin="dist/kiwiberry-${target}"
+            if ! codesign -dvv "$bin" 2>&1 | grep -q 'Signature='; then
+              echo "ERROR: $bin is unsigned — macOS Gatekeeper will SIGKILL it" >&2
+              codesign -dvv "$bin" 2>&1 || true
+              exit 1
+            fi
+          done
+
+      - name: Upload darwin binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: darwin-binaries
+          path: dist/kiwiberry-darwin-*
+          if-no-files-found: error
+          retention-days: 1
+
   release:
     runs-on: ubuntu-latest
+    needs: darwin-build
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -29,13 +69,23 @@ jobs:
       - name: Lint
         run: bun run lint
 
-      - name: Cross-compile all targets
-        run: bun run build:all
+      - name: Build linux and windows targets
+        run: |
+          bun run build:linux-x64
+          bun run build:linux-arm64
+          bun run build:windows-x64
+
+      - name: Download darwin binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: darwin-binaries
+          path: dist
 
       - name: Package release archives
         run: |
           set -euo pipefail
           mkdir -p release
+          chmod +x dist/kiwiberry-darwin-arm64 dist/kiwiberry-darwin-x64
 
           package_unix() {
             local target="$1"


### PR DESCRIPTION
## Summary
- Cross-compiling darwin targets on `ubuntu-latest` produced completely unsigned Mach-O binaries; macOS SIGKILLs them on launch (discovered by `/release-smoke-test` against `v0.0.0-rc1`).
- Split `release.yml` into a `darwin-build` job on `macos-latest` (where Bun's linker-signing runs) and a dependent `release` job on `ubuntu-latest` that downloads the signed darwin binaries before packaging.
- Added a `codesign -dvv` check in `darwin-build` so any future regression fails the job loudly instead of shipping broken binaries again.

## Test plan
- [ ] CI runs green on this PR (though the release workflow only fires on tag push — merge first, then re-smoke)
- [ ] After merge, re-run `/release-smoke-test` with `v0.0.0-rc2`
- [ ] Verify the darwin binary from rc2 reports `Signature=adhoc` under `codesign -dvv`
- [ ] Verify the darwin binary actually executes (`kiwiberry --help` prints usage, exit 0)
- [ ] Spot-check linux/windows archives still land (packaging untouched, but paranoia is cheap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)