### PR TITLE
Pin Bun to 1.3.11 to work around darwin signing regression

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Pinned: Bun 1.3.12 stopped linker-signing darwin --compile output,
+      # producing binaries macOS SIGKILLs on launch. Unpin once upstream fixes.
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: "1.3.11"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -58,7 +60,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: "1.3.11"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile


### PR DESCRIPTION
## Summary
- Bun 1.3.12's `bun build --compile` stopped linker-signing darwin binaries — the Mach-O output ships with no signature at all and macOS SIGKILLs it on launch.
- Reproduced locally with both `--target=bun-darwin-arm64` and native builds: 1.3.11 produces `Signature=adhoc` (linker-signed), 1.3.12 produces `code object is not signed at all`.
- `codesign --force --sign -` cannot salvage the 1.3.12 output — it errors with "invalid or unsupported format for signature", so post-hoc ad-hoc signing is not a viable workaround.
- Pin both release jobs to `1.3.11` until the upstream regression is fixed.

Caught by `/release-smoke-test` against `v0.0.0-rc2` (on top of #22, which added the matrix + verify step — without that step, the regression would have shipped silently again).

## Test plan
- [ ] Merge and re-run `/release-smoke-test` with `v0.0.0-rc3`
- [ ] Verify the darwin binaries from rc3 pass the `codesign` check in `darwin-build`
- [ ] Verify the downloaded darwin-arm64 binary executes (`kiwiberry --help` prints usage, exit 0)
- [ ] TODO (follow-up, not blocking): file a Bun upstream issue for the 1.3.12 darwin signing regression so we can eventually unpin

🤖 Generated with [Claude Code](https://claude.com/claude-code)