### PR TITLE
Verify darwin signing with codesign --verify, not grep

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,11 +35,12 @@ jobs:
           set -euo pipefail
           for target in darwin-arm64 darwin-x64; do
             bin="dist/kiwiberry-${target}"
-            if ! codesign -dvv "$bin" 2>&1 | grep -q 'Signature='; then
-              echo "ERROR: $bin is unsigned — macOS Gatekeeper will SIGKILL it" >&2
+            if ! codesign --verify "$bin" 2>/dev/null; then
+              echo "ERROR: $bin has no valid code signature — macOS will SIGKILL it" >&2
               codesign -dvv "$bin" 2>&1 || true
               exit 1
             fi
+            codesign -dvv "$bin" 2>&1 | grep -E 'Signature|Authority|Identifier' || true
           done
 
       - name: Upload darwin binaries


### PR DESCRIPTION
## Summary
- The verify step added in #22 grepped for `Signature=` in `codesign -dvv` output, which works for linker-signed adhoc binaries (which emit `Signature=adhoc`) but misses Developer-ID-signed binaries where the line is `Signature size=<n>`.
- `bun-darwin-x64` ships pre-signed with a full Developer ID (`Authority=Developer ID Application: Jarred Sumner (7FRXF46ZSN)`), which Bun copies into the compiled output. So rc3's darwin-x64 binary was actually correctly signed — the verify step was just wrong.
- Switch to `codesign --verify` (exit-status-based). It correctly rejects unsigned/malformed binaries and accepts both linker-signed adhoc and Developer ID signed binaries.
- Also logs relevant codesign lines on success so future failures are diagnosable from CI logs alone.

Caught by `/release-smoke-test` against `v0.0.0-rc3` (Bun 1.3.11 pin from #23 works correctly; the verify step itself was buggy).

## Test plan
- [ ] Merge and re-run `/release-smoke-test` with `v0.0.0-rc4`
- [ ] Verify `darwin-build` passes the codesign check for both arm64 and x64
- [ ] Verify the downloaded darwin-arm64 binary executes (`kiwiberry --help` prints usage, exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)