### PR TITLE
Verify darwin binaries by execution, not strict codesign

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,18 +30,28 @@ jobs:
           bun run build:darwin-arm64
           bun run build:darwin-x64
 
-      - name: Verify darwin binaries are signed
+      - name: Verify darwin binaries are signed and runnable
         run: |
           set -euo pipefail
+          # `codesign --verify` is too strict — it rejects linker-signed adhoc
+          # binaries that actually run fine. The real regression we're guarding
+          # against (Bun 1.3.12) produces output literally saying "not signed
+          # at all", so match on that string.
           for target in darwin-arm64 darwin-x64; do
             bin="dist/kiwiberry-${target}"
-            if ! codesign --verify "$bin" 2>/dev/null; then
-              echo "ERROR: $bin has no valid code signature — macOS will SIGKILL it" >&2
-              codesign -dvv "$bin" 2>&1 || true
+            info="$(codesign -dvv "$bin" 2>&1)"
+            if echo "$info" | grep -q 'not signed at all'; then
+              echo "ERROR: $bin is completely unsigned — macOS will SIGKILL it" >&2
+              echo "$info" >&2
               exit 1
             fi
-            codesign -dvv "$bin" 2>&1 | grep -E 'Signature|Authority|Identifier' || true
+            echo "$info" | grep -E 'Signature|Authority|Identifier|flags=' || true
           done
+          # Secondary: actually launch the native-arch binary. macos-latest is
+          # arm64, so we can run darwin-arm64 directly; x64 would need Rosetta
+          # and is left to the codesign string check above.
+          chmod +x dist/kiwiberry-darwin-arm64
+          dist/kiwiberry-darwin-arm64 --version
 
       - name: Upload darwin binaries
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- #24's switch to \`codesign --verify\` turned out to be too strict. It rejects linker-signed adhoc binaries with \`invalid signature (code or signature have been modified)\` even though they launch and run fine on macOS. That's the normal state of \`bun build --compile\` output — linker-signed signatures lack the hashes that full adhoc signing produces.
- Replace with a two-part check: (1) grep \`codesign -dvv\` output for the literal \`not signed at all\` string (the exact Bun 1.3.12 regression we're guarding against), and (2) actually launch the darwin-arm64 binary with \`--version\` on the arm64 runner — the authoritative "will it run on a user's Mac" test.
- darwin-x64 is not executed because macos-latest is arm64; Rosetta setup is out of scope. The codesign string check is sufficient since the only darwin-x64 failure mode we've seen is the completely-unsigned 1.3.12 output.

Caught by \`/release-smoke-test\` against \`v0.0.0-rc4\` — the rc4 darwin-arm64 binary had \`Signature=adhoc\` / \`flags=0x20002(adhoc,linker-signed)\` but \`codesign --verify\` still failed it.

## Test plan
- [ ] Merge and re-run \`/release-smoke-test\` with \`v0.0.0-rc5\`
- [ ] darwin-build's verify step passes
- [ ] The \`--version\` execution step inside verify prints a version string and exits 0
- [ ] Downloaded darwin-arm64 binary runs on the host (\`kiwiberry --help\`, \`kiwiberry business list\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)