### PR TITLE
Support KIWIBERRY_DB_DIR and bump actions to node24

### DIFF
--- a/.claude/skills/release-smoke-test/SKILL.md
+++ b/.claude/skills/release-smoke-test/SKILL.md
@@ -115,10 +115,11 @@ KIWIBERRY_INSTALL_DIR="$SMOKE_DIR" \
 
 ```bash
 SMOKE_DIR_CURL="/tmp/kiwiberry-rc-smoke-curl-$$"
-KIWIBERRY_VERSION=v0.0.0-rcN \
-KIWIBERRY_INSTALL_DIR="$SMOKE_DIR_CURL" \
-  curl -fsSL https://raw.githubusercontent.com/montekakabot/kiwiberry-cli/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/montekakabot/kiwiberry-cli/main/install.sh | \
+  KIWIBERRY_VERSION=v0.0.0-rcN KIWIBERRY_INSTALL_DIR="$SMOKE_DIR_CURL" bash
 ```
+
+Note the env vars go **after** the pipe, scoped to `bash`, not to `curl`. Setting them before `curl` scopes them to the curl process and they never reach the install script — the script then defaults to `latest` and `~/.local/bin`, silently polluting the user's real install directory.
 
 Both should print `Downloading ...`, `Fetching .../SHA256SUMS`, `Checksum verified.`, and `Installed kiwiberry → ...`.
 
@@ -135,15 +136,15 @@ xattr -d com.apple.quarantine "$SMOKE_DIR/kiwiberry" 2>/dev/null || true
 "$SMOKE_DIR/kiwiberry" --help
 ```
 
-`--version` must print a version string (currently tracks `package.json`). Then do a minimum end-to-end check that doesn't touch the real `~/.kiwiberry` database:
+`--version` must print a version string (currently tracks `package.json`). Then do a minimum end-to-end check against an isolated DB directory — **never** run against `~/.kiwiberry`:
 
 ```bash
 KIWIBERRY_DB_DIR="$SMOKE_DIR/data" "$SMOKE_DIR/kiwiberry" business list
 ```
 
-(If `KIWIBERRY_DB_DIR` is not supported, fall back to temporarily renaming `~/.kiwiberry` or running `business list` and trusting the user can tolerate the real DB being touched — **ask the user first** before touching their real database.)
+`KIWIBERRY_DB_DIR` is wired through `defaultDataDir()` in `src/db/index.ts` and every command respects it. If a future refactor breaks that wiring, verify the isolated dir actually got created (`ls "$SMOKE_DIR/data"`) before trusting the output; an empty stdout with a missing dir means the binary fell back to `~/.kiwiberry` and you've just touched the user's real database. Stop and ask the user if that happens.
 
-A fresh DB + `business list` should return `[]` on stdout with no errors on stderr. That proves:
+A fresh DB + `business list` should return `[]` on stdout with no errors on stderr, and `$SMOKE_DIR/data/kiwiberry.db` should exist afterward. That proves:
 - The binary starts
 - Bundled migrations apply against a brand-new SQLite file
 - JSON-on-stdout contract holds

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Pinned: Bun 1.3.12 stopped linker-signing darwin --compile output,
       # producing binaries macOS SIGKILLs on launch. Unpin once upstream fixes.
@@ -54,7 +54,7 @@ jobs:
           dist/kiwiberry-darwin-arm64 --version
 
       - name: Upload darwin binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: darwin-binaries
           path: dist/kiwiberry-darwin-*
@@ -66,7 +66,7 @@ jobs:
     needs: darwin-build
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -89,7 +89,7 @@ jobs:
           bun run build:windows-x64
 
       - name: Download darwin binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: darwin-binaries
           path: dist

--- a/src/commands/business.ts
+++ b/src/commands/business.ts
@@ -1,11 +1,9 @@
 import { defineCommand } from "citty";
-import { homedir } from "os";
-import { join } from "path";
-import { getDatabase } from "../db";
+import { defaultDataDir, getDatabase } from "../db";
 import { addBusiness, listBusinesses, removeBusiness } from "../services/business";
 
 function getDb() {
-  return getDatabase(join(homedir(), ".kiwiberry"));
+  return getDatabase(defaultDataDir());
 }
 
 const add = defineCommand({

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,11 +1,9 @@
 import { defineCommand } from "citty";
-import { homedir } from "os";
-import { join } from "path";
-import { getDatabase } from "../db";
+import { defaultDataDir, getDatabase } from "../db";
 import { getConfig, setConfig } from "../services/config";
 
 function getDb() {
-  return getDatabase(join(homedir(), ".kiwiberry"));
+  return getDatabase(defaultDataDir());
 }
 
 const get = defineCommand({

--- a/src/commands/fetch.ts
+++ b/src/commands/fetch.ts
@@ -1,15 +1,13 @@
 import { defineCommand } from "citty";
 import { eq } from "drizzle-orm";
-import { homedir } from "os";
-import { join } from "path";
-import { getDatabase } from "../db";
+import { defaultDataDir, getDatabase } from "../db";
 import { businesses } from "../db/schema";
 import { getConfig } from "../services/config";
 import { syncReviews } from "../services/review";
 import { scrapeReviews } from "../services/scraper";
 
 function getDb() {
-  return getDatabase(join(homedir(), ".kiwiberry"));
+  return getDatabase(defaultDataDir());
 }
 
 export default defineCommand({

--- a/src/commands/respond.ts
+++ b/src/commands/respond.ts
@@ -1,11 +1,9 @@
 import { defineCommand } from "citty";
-import { homedir } from "os";
-import { join } from "path";
-import { getDatabase } from "../db";
+import { defaultDataDir, getDatabase } from "../db";
 import { addDraftResponse } from "../services/response";
 
 function getDb() {
-  return getDatabase(join(homedir(), ".kiwiberry"));
+  return getDatabase(defaultDataDir());
 }
 
 export default defineCommand({

--- a/src/commands/responses.ts
+++ b/src/commands/responses.ts
@@ -1,11 +1,9 @@
 import { defineCommand } from "citty";
-import { homedir } from "os";
-import { join } from "path";
-import { getDatabase } from "../db";
+import { defaultDataDir, getDatabase } from "../db";
 import { listDraftResponses } from "../services/response";
 
 function getDb() {
-  return getDatabase(join(homedir(), ".kiwiberry"));
+  return getDatabase(defaultDataDir());
 }
 
 export default defineCommand({

--- a/src/commands/reviews.ts
+++ b/src/commands/reviews.ts
@@ -1,11 +1,9 @@
 import { defineCommand } from "citty";
-import { homedir } from "os";
-import { join } from "path";
-import { getDatabase } from "../db";
+import { defaultDataDir, getDatabase } from "../db";
 import { listReviews } from "../services/review";
 
 function getDb() {
-  return getDatabase(join(homedir(), ".kiwiberry"));
+  return getDatabase(defaultDataDir());
 }
 
 export default defineCommand({

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,10 +1,15 @@
 import { mkdirSync } from "fs";
+import { homedir } from "os";
 import { join } from "path";
 import { Database } from "bun:sqlite";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 import * as schema from "./schema";
 import { bundledMigrations } from "./migrations";
 import { applyBundledMigrations } from "./migrator";
+
+export function defaultDataDir(): string {
+  return process.env.KIWIBERRY_DB_DIR ?? join(homedir(), ".kiwiberry");
+}
 
 export function getDatabase(dataDir: string) {
   mkdirSync(dataDir, { recursive: true });

--- a/test/db.test.ts
+++ b/test/db.test.ts
@@ -1,9 +1,9 @@
 import { describe, test, expect, afterEach } from "bun:test";
 import { rmSync, existsSync } from "fs";
+import { homedir, tmpdir } from "os";
 import { join } from "path";
-import { tmpdir } from "os";
 import { eq } from "drizzle-orm";
-import { getDatabase } from "../src/db";
+import { defaultDataDir, getDatabase } from "../src/db";
 import { businesses, reviews, draftResponses, config } from "../src/db/schema";
 
 function makeTempDir(): string {
@@ -79,6 +79,23 @@ describe("getDatabase", () => {
 
     expect(rows).toHaveLength(1);
     expect(rows[0].name).toBe("Persistent Biz");
+  });
+
+  test("defaultDataDir honors KIWIBERRY_DB_DIR env var", () => {
+    const original = process.env.KIWIBERRY_DB_DIR;
+    try {
+      process.env.KIWIBERRY_DB_DIR = "/tmp/kiwiberry-env-override";
+      expect(defaultDataDir()).toBe("/tmp/kiwiberry-env-override");
+
+      delete process.env.KIWIBERRY_DB_DIR;
+      expect(defaultDataDir()).toBe(join(homedir(), ".kiwiberry"));
+    } finally {
+      if (original === undefined) {
+        delete process.env.KIWIBERRY_DB_DIR;
+      } else {
+        process.env.KIWIBERRY_DB_DIR = original;
+      }
+    }
   });
 
   test("deleting a business cascades to reviews and draft responses", () => {


### PR DESCRIPTION
## Summary
- Add `defaultDataDir()` helper so every command honors `KIWIBERRY_DB_DIR`, letting the release smoke test (and any isolated run) avoid touching `~/.kiwiberry`
- Bump `actions/checkout@v4→v6`, `actions/upload-artifact@v4→v7`, `actions/download-artifact@v4→v8` to clear the Node 20 deprecation warnings (`softprops/action-gh-release@v2` has no newer major yet, so one warning will remain)
- Fix two bugs in the `release-smoke-test` skill surfaced during the last dry run: the `curl | bash` example had env vars scoped to `curl` instead of `bash`, and the `KIWIBERRY_DB_DIR` section previously assumed support that didn't exist

## Test plan
- [x] `bun test` (74 pass)
- [x] `bun run lint` clean
- [ ] Next smoke test run exercises the new `KIWIBERRY_DB_DIR=$SMOKE_DIR/data` path end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)