### PR TITLE
Fix review text parser to ignore business owner widget (#29)

### DIFF
--- a/src/services/scraper.ts
+++ b/src/services/scraper.ts
@@ -60,24 +60,24 @@ export function findNextPageRef(snapshot: string): string | null {
 //               `- text:` children are the review paragraphs (reviewers with
 //               photos or Elite status render this way).
 function extractReviewText(block: string): string | null {
-  const paragraphStart = /- paragraph \[ref=\w+\]:(.*)$/m.exec(block);
+  const paragraphStart = /^(\s*)- paragraph \[ref=\w+\]:(.*)$/m.exec(block);
   if (paragraphStart?.index === undefined) return null;
 
-  const inline = paragraphStart[1].trim();
+  const inline = paragraphStart[2].trim();
   if (inline.length > 0) return inline;
 
-  // Collect contiguous `- text:` children within the paragraph's subtree.
+  // Nested form: `- text:` descendants live strictly below the paragraph's
+  // indent. As soon as we see a non-blank line at or above that indent we've
+  // left the paragraph subtree (e.g. a sibling `- generic` wrapping reactions).
+  const paragraphIndent = paragraphStart[1].length;
   const afterParagraph = block.substring(paragraphStart.index + paragraphStart[0].length);
   const textLines: string[] = [];
   for (const line of afterParagraph.split("\n")) {
+    if (line.trim().length === 0) continue;
+    const indent = line.length - line.trimStart().length;
+    if (indent <= paragraphIndent) break;
     const textMatch = /^\s+- text: (.+)$/.exec(line);
-    if (textMatch) {
-      textLines.push(textMatch[1].trim());
-      continue;
-    }
-    if (textLines.length > 0 && /^\s*- \w/.test(line) && !/^\s+- generic/.test(line)) {
-      break;
-    }
+    if (textMatch) textLines.push(textMatch[1].trim());
   }
   return textLines.length > 0 ? textLines.join("\n\n") : null;
 }

--- a/src/services/scraper.ts
+++ b/src/services/scraper.ts
@@ -54,6 +54,34 @@ export function findNextPageRef(snapshot: string): string | null {
   return match?.[1] ?? null;
 }
 
+// Review text appears in two shapes in Yelp's accessibility snapshot:
+//   1. Inline:  `- paragraph [ref=e1]: the whole review on one line`
+//   2. Nested:  `- paragraph [ref=e1]:` with a `- generic` child whose
+//               `- text:` children are the review paragraphs (reviewers with
+//               photos or Elite status render this way).
+function extractReviewText(block: string): string | null {
+  const paragraphStart = /- paragraph \[ref=\w+\]:(.*)$/m.exec(block);
+  if (paragraphStart?.index === undefined) return null;
+
+  const inline = paragraphStart[1].trim();
+  if (inline.length > 0) return inline;
+
+  // Collect contiguous `- text:` children within the paragraph's subtree.
+  const afterParagraph = block.substring(paragraphStart.index + paragraphStart[0].length);
+  const textLines: string[] = [];
+  for (const line of afterParagraph.split("\n")) {
+    const textMatch = /^\s+- text: (.+)$/.exec(line);
+    if (textMatch) {
+      textLines.push(textMatch[1].trim());
+      continue;
+    }
+    if (textLines.length > 0 && /^\s*- \w/.test(line) && !/^\s+- generic/.test(line)) {
+      break;
+    }
+  }
+  return textLines.length > 0 ? textLines.join("\n\n") : null;
+}
+
 export function parseReviewsFromSnapshot(snapshot: string): ScrapedReview[] {
   const reviews: ScrapedReview[] = [];
   const now = new Date().toISOString();
@@ -70,9 +98,17 @@ export function parseReviewsFromSnapshot(snapshot: string): ScrapedReview[] {
     const startIdx = match.index;
     // Bound the block by the next listitem
     const nextListitem = snapshot.indexOf("- listitem", startIdx + 10);
-    const block = nextListitem > 0
+    let block = nextListitem > 0
       ? snapshot.substring(startIdx, nextListitem)
       : snapshot.substring(startIdx);
+
+    // Yelp injects a sibling "Business owner information" region containing
+    // the owner's response. Trim the block there so its paragraphs can't be
+    // mistaken for the reviewer's own text.
+    const ownerWidgetIdx = block.indexOf("- region \"Business owner information\"");
+    if (ownerWidgetIdx >= 0) {
+      block = block.substring(0, ownerWidgetIdx);
+    }
 
     // Extract userId from /url: /user_details?userid=...
     const userIdMatch = /\/user_details\?userid=([\w-]+)/.exec(block);
@@ -95,9 +131,7 @@ export function parseReviewsFromSnapshot(snapshot: string): ScrapedReview[] {
 
     const postedAtIso = new Date(postedAtRaw).toISOString().split("T")[0];
 
-    // Extract review text
-    const textMatch = /- paragraph \[ref=\w+\]: (.+)/.exec(block);
-    const reviewText = textMatch?.[1]?.trim();
+    const reviewText = extractReviewText(block);
     if (!reviewText) continue;
 
     reviews.push({

--- a/test/scraper.test.ts
+++ b/test/scraper.test.ts
@@ -239,6 +239,35 @@ describe("parseReviewsFromSnapshot", () => {
     expect(reviews[0].reviewText).toContain("I do not recommend Meet Fresh.");
   });
 
+  test("stops scanning at paragraph boundary, ignoring sibling generic subtrees", () => {
+    // After the review paragraph, Yelp renders a sibling `- generic` for
+    // reactions whose buttons contain `- text:` labels like "Useful 3".
+    // The parser must not append those to the review text.
+    const snapshot = `
+- list [ref=e1]:
+  - listitem [ref=e2]:
+    - region "Dana P." [ref=e3]:
+      - link [ref=e4]:
+        - /url: /user_details?userid=abc123
+      - generic [ref=e5]: San Diego, CA
+    - generic [ref=e6]:
+      - img "5 star rating" [ref=e7]
+      - generic [ref=e8]: Apr 2, 2026
+      - paragraph [ref=e9]:
+        - generic [ref=e10]:
+          - text: Actual review sentence.
+      - generic [ref=e11]:
+        - generic [ref=e12]:
+          - text: Useful 3
+  - listitem [ref=e20]:
+`;
+    const reviews = parseReviewsFromSnapshot(snapshot);
+
+    expect(reviews).toHaveLength(1);
+    expect(reviews[0].reviewerName).toBe("Dana P.");
+    expect(reviews[0].reviewText).toBe("Actual review sentence.");
+  });
+
   test("joins nested text children from multi-paragraph review body", () => {
     // Reviewers with photos render multi-paragraph bodies as sibling `- text:`
     // children; the parser must join them rather than dropping the review

--- a/test/scraper.test.ts
+++ b/test/scraper.test.ts
@@ -199,4 +199,74 @@ describe("parseReviewsFromSnapshot", () => {
     expect(reviews[0].reviewText).toBe("Amazing shaved ice!");
     expect(reviews[0].fetchedAtIso).toBeDefined();
   });
+
+  test("ignores business-owner response widget when extracting review text", () => {
+    // Real Yelp snapshots inject a "Business owner information" region
+    // alongside the reviewer's content. The review text itself is nested as
+    // `- text:` children under a refless `- generic` inside the paragraph.
+    // Previously the parser captured the owner-widget paragraph label
+    // ("Business owner information") instead of the reviewer's actual text.
+    const snapshot = `
+- list [ref=e1]:
+  - listitem [ref=e1368]:
+    - generic [ref=e1369]:
+      - generic [ref=e1371]:
+        - region "lisa j." [ref=e1373]:
+          - link [ref=e1377]:
+            - /url: /user_details?userid=x-oG4OvNbXOmhT5U7BDzfw
+          - generic [ref=e1386]: San Diego, CA
+      - generic [ref=e1402]:
+        - generic [ref=e1404]:
+          - img "1 star rating" [ref=e1408]
+          - generic [ref=e1434]: Apr 5, 2026
+        - paragraph [ref=e1445]:
+          - generic [ref=e1446]:
+            - text: Maybe I ordered the wrong drink.
+            - text: I do not recommend Meet Fresh.
+      - generic [ref=e1497]:
+        - region "Business owner information" [ref=e1500]:
+          - paragraph [ref=e1501]: Business owner information
+          - paragraph [ref=e1508]: Store M.
+          - paragraph [ref=e1510]: Business Manager
+  - listitem [ref=e1524]:
+`;
+    const reviews = parseReviewsFromSnapshot(snapshot);
+
+    expect(reviews).toHaveLength(1);
+    expect(reviews[0].reviewerName).toBe("lisa j.");
+    expect(reviews[0].reviewText).not.toContain("Business owner information");
+    expect(reviews[0].reviewText).toContain("Maybe I ordered the wrong drink.");
+    expect(reviews[0].reviewText).toContain("I do not recommend Meet Fresh.");
+  });
+
+  test("joins nested text children from multi-paragraph review body", () => {
+    // Reviewers with photos render multi-paragraph bodies as sibling `- text:`
+    // children; the parser must join them rather than dropping the review
+    // because no inline paragraph text exists.
+    const snapshot = `
+- list [ref=e1]:
+  - listitem [ref=e2]:
+    - region "Alan X." [ref=e3]:
+      - link [ref=e4]:
+        - /url: /user_details?userid=w-AxQ3Ghlsy6_4QN45lH0w
+      - generic [ref=e5]: San Diego, CA
+      - img "3 star rating" [ref=e6]
+      - generic [ref=e7]: Mar 26, 2026
+      - paragraph [ref=e8]:
+        - generic [ref=e9]:
+          - text: I got the chocolate egg waffle. Not bad.
+          - text: The service kinda sucked.
+          - text: Ambiance is good but the table was sticky.
+  - listitem [ref=e20]:
+`;
+    const reviews = parseReviewsFromSnapshot(snapshot);
+
+    expect(reviews).toHaveLength(1);
+    expect(reviews[0].reviewerName).toBe("Alan X.");
+    expect(reviews[0].reviewText).toBe(
+      "I got the chocolate egg waffle. Not bad.\n\n"
+      + "The service kinda sucked.\n\n"
+      + "Ambiance is good but the table was sticky."
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- Trim each review block at `- region "Business owner information"` so the owner-response widget can no longer leak into the reviewer's text (fixes lisa j.'s stored `Business owner information`).
- Extract review text via a new `extractReviewText` helper that handles both snapshot shapes: inline `- paragraph [ref=…]: text` and nested `- paragraph [ref=…]:` with `- text:` children joined by `\n\n` — the latter was silently dropping reviews (e.g. Alan X.) entirely.

Closes #29.

## Test plan
- [x] `bun test` — 76/76 passing, incl. two new TDD cases in `test/scraper.test.ts`: owner-widget suppression and nested multi-paragraph joining.
- [x] `bun run lint` — clean.
- [x] End-to-end: ran the new parser against a freshly captured `meet-fresh-san-diego?sort_by=date_desc` snapshot — lisa j.'s full 3-paragraph review is captured, Alan X.'s review is now parsed (was previously dropped), Jennifer X.'s inline paragraph still works.