### PR TITLE
Fix snapshot parser for openclaw 2026.4.11 format

### DIFF
--- a/src/services/scraper.ts
+++ b/src/services/scraper.ts
@@ -54,78 +54,165 @@ export function findNextPageRef(snapshot: string): string | null {
   return match?.[1] ?? null;
 }
 
-// Review text appears in two shapes in Yelp's accessibility snapshot:
+// Review text appears in several shapes depending on the openclaw version:
+//
+// Old format (pre-2026.4.11):
 //   1. Inline:  `- paragraph [ref=e1]: the whole review on one line`
-//   2. Nested:  `- paragraph [ref=e1]:` with a `- generic` child whose
-//               `- text:` children are the review paragraphs (reviewers with
-//               photos or Elite status render this way).
+//   2. Nested:  `- paragraph [ref=e1]:` with `- text:` children
+//
+// New format (openclaw 2026.4.11+):
+//   3. `statictext "review text"` — one or more, separated by `linebreak`
+//
+// The location and date are also `statictext` in the new format, so those
+// are excluded by pattern matching (city/state, month-day-year).
 function extractReviewText(block: string): string | null {
+  // Try old format first: paragraph-based extraction
   const paragraphStart = /^(\s*)- paragraph \[ref=\w+\]:(.*)$/m.exec(block);
-  if (paragraphStart?.index === undefined) return null;
+  if (paragraphStart?.index !== undefined) {
+    const inline = paragraphStart[2].trim();
+    if (inline.length > 0) return inline;
 
-  const inline = paragraphStart[2].trim();
-  if (inline.length > 0) return inline;
-
-  // Nested form: `- text:` descendants live strictly below the paragraph's
-  // indent. As soon as we see a non-blank line at or above that indent we've
-  // left the paragraph subtree (e.g. a sibling `- generic` wrapping reactions).
-  const paragraphIndent = paragraphStart[1].length;
-  const afterParagraph = block.substring(paragraphStart.index + paragraphStart[0].length);
-  const textLines: string[] = [];
-  for (const line of afterParagraph.split("\n")) {
-    if (line.trim().length === 0) continue;
-    const indent = line.length - line.trimStart().length;
-    if (indent <= paragraphIndent) break;
-    const textMatch = /^\s+- text: (.+)$/.exec(line);
-    if (textMatch) textLines.push(textMatch[1].trim());
+    const paragraphIndent = paragraphStart[1].length;
+    const afterParagraph = block.substring(paragraphStart.index + paragraphStart[0].length);
+    const textLines: string[] = [];
+    for (const line of afterParagraph.split("\n")) {
+      if (line.trim().length === 0) continue;
+      const indent = line.length - line.trimStart().length;
+      if (indent <= paragraphIndent) break;
+      const textMatch = /^\s+- text: (.+)$/.exec(line);
+      if (textMatch) textLines.push(textMatch[1].trim());
+    }
+    if (textLines.length > 0) return textLines.join("\n\n");
   }
-  return textLines.length > 0 ? textLines.join("\n\n") : null;
+
+  // New format: collect `statictext` lines that aren't location or date
+  return extractStaticTextReview(block);
+}
+
+const DATE_PATTERN = /^(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{1,2}, \d{4}$/;
+
+function extractStaticTextReview(block: string): string | null {
+  // In the new format the region contains reviewer info (name, location) as
+  // children, while the review content (rating, date, text) are siblings at
+  // the same indent level as the region. Since the block string starts at the
+  // region's `-`, we detect the child indent from the first indented line and
+  // only include statictext at a shallower indent (siblings).
+  const lines = block.split("\n");
+  let childIndent = Infinity;
+  for (let i = 1; i < lines.length; i++) {
+    const trimmed = lines[i].trimStart();
+    if (trimmed.length === 0) continue;
+    const indent = lines[i].length - trimmed.length;
+    if (indent > 0) {
+      childIndent = indent;
+      break;
+    }
+  }
+
+  const textParts: string[] = [];
+  for (const line of lines.slice(1)) {
+    const trimmed = line.trimStart();
+    if (trimmed.length === 0) continue;
+    const indent = line.length - trimmed.length;
+    // Skip lines indented at child level or deeper (region children)
+    if (indent >= childIndent) continue;
+    const m = /- statictext "([^"]+)"/.exec(line);
+    if (!m) continue;
+    const text = m[1];
+    if (DATE_PATTERN.test(text)) continue;
+    if (/^\d+ star rating$/.test(text)) continue;
+    textParts.push(text);
+  }
+  return textParts.length > 0 ? textParts.join("\n\n") : null;
+}
+
+function slugify(name: string): string {
+  const slug = name
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+  return slug.length > 0 ? slug : "unknown";
 }
 
 export function parseReviewsFromSnapshot(snapshot: string): ScrapedReview[] {
   const reviews: ScrapedReview[] = [];
   const now = new Date().toISOString();
 
-  // Split snapshot into review blocks by looking for region elements with reviewer names
-  const regionPattern = /- region "([^"]+)" \[ref=\w+\]:/g;
+  // Every region whose name ends with "." is a reviewer. Collect all region
+  // matches so we can bound each reviewer's block by the next region.
+  const regionPattern = /- region "([^"]+)" \[ref=\w+\]:?/g;
   const matches = [...snapshot.matchAll(regionPattern)];
 
-  for (const match of matches) {
+  for (let i = 0; i < matches.length; i++) {
+    const match = matches[i];
     const reviewerName = match[1];
-    // Skip non-reviewer regions
+    // Skip non-reviewer regions (e.g. "Recommended Reviews", "Menu")
     if (!reviewerName.endsWith(".")) continue;
 
     const startIdx = match.index;
-    // Bound the block by the next listitem
+    const startIndent = startIdx - snapshot.lastIndexOf("\n", startIdx) - 1;
+
+    // Bound the block: in old format by next listitem, in new format (and as
+    // a general fallback) by the next region at the same or shallower indent.
     const nextListitem = snapshot.indexOf("- listitem", startIdx + 10);
-    let block = nextListitem > 0
-      ? snapshot.substring(startIdx, nextListitem)
+    let nextRegionIdx = -1;
+    for (let j = i + 1; j < matches.length; j++) {
+      const candidateIdx = matches[j].index;
+      const candidateIndent = candidateIdx - snapshot.lastIndexOf("\n", candidateIdx) - 1;
+      if (candidateIndent <= startIndent) {
+        nextRegionIdx = candidateIdx;
+        break;
+      }
+    }
+    let endIdx = -1;
+    if (nextListitem > 0 && nextRegionIdx > 0) {
+      endIdx = Math.min(nextListitem, nextRegionIdx);
+    } else if (nextListitem > 0) {
+      endIdx = nextListitem;
+    } else if (nextRegionIdx > 0) {
+      endIdx = nextRegionIdx;
+    }
+    let block = endIdx > 0
+      ? snapshot.substring(startIdx, endIdx)
       : snapshot.substring(startIdx);
 
-    // Yelp injects a sibling "Business owner information" region containing
-    // the owner's response. Trim the block there so its paragraphs can't be
-    // mistaken for the reviewer's own text.
+    // Trim at "Business owner information" region so owner-response text
+    // doesn't pollute the reviewer's review.
     const ownerWidgetIdx = block.indexOf("- region \"Business owner information\"");
     if (ownerWidgetIdx >= 0) {
       block = block.substring(0, ownerWidgetIdx);
     }
 
-    // Extract userId from /url: /user_details?userid=...
-    const userIdMatch = /\/user_details\?userid=([\w-]+)/.exec(block);
-    const userId = userIdMatch?.[1];
-    if (!userId) continue;
-
-    // Extract location
-    const locationMatch = /- generic \[ref=\w+\]: ([A-Z][^"\n]+(?:,\s*[A-Z]{2}))/.exec(block);
+    // Location (old: `generic [ref=...]: City, CA`; new: `statictext "City, CA"`)
+    // In the new format, location is a child of the region (indented). Search
+    // only the children subtree so sibling review text can't be misattributed.
+    const regionLineEnd = block.indexOf("\n");
+    const childLines: string[] = [];
+    if (regionLineEnd >= 0) {
+      for (const line of block.substring(regionLineEnd + 1).split("\n")) {
+        if (line.trim().length === 0) continue;
+        const indent = line.length - line.trimStart().length;
+        if (indent <= startIndent) break;
+        childLines.push(line);
+      }
+    }
+    const childBlock = childLines.join("\n");
+    const locationMatch
+      = /- generic \[ref=\w+\]: ([A-Z][^"\n]+(?:,\s*[A-Z]{2}))/.exec(block)
+        ?? /- statictext "([A-Z][^"]+(?:,\s*[A-Z]{2}))"/.exec(childBlock);
     const reviewerLocation = locationMatch?.[1] ?? null;
 
-    // Extract rating
-    const ratingMatch = /img "(\d+) star rating"/.exec(block);
+    // Rating (old: `img`; new: `image`)
+    const ratingMatch = /(?:img|image) "(\d+) star rating"/.exec(block);
     const rating = ratingMatch ? parseInt(ratingMatch[1]) : null;
     if (rating === null) continue;
 
-    // Extract date
-    const dateMatch = /- generic \[ref=\w+\]: ((?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{1,2}, \d{4})/.exec(block);
+    // Date (old: `generic [ref=...]: Apr 1, 2026`; new: `statictext "Apr 1, 2026"`)
+    const dateMatch
+      = /- generic \[ref=\w+\]: ((?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{1,2}, \d{4})/.exec(block)
+        ?? /- statictext "((?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{1,2}, \d{4})"/.exec(block);
     const postedAtRaw = dateMatch?.[1] ?? null;
     if (!postedAtRaw) continue;
 
@@ -133,6 +220,12 @@ export function parseReviewsFromSnapshot(snapshot: string): ScrapedReview[] {
 
     const reviewText = extractReviewText(block);
     if (!reviewText) continue;
+
+    // userId: prefer real Yelp ID from /url: line (old format). When absent
+    // (new format), fall back to a slug of the reviewer's display name.
+    const userIdMatch = /\/user_details\?userid=([\w-]+)/.exec(block);
+    const userId = userIdMatch?.[1]
+      ?? slugify(reviewerName);
 
     reviews.push({
       userId,

--- a/test/scraper.test.ts
+++ b/test/scraper.test.ts
@@ -14,6 +14,23 @@ const VALID_SNAPSHOT = `
   - listitem [ref=e9]:
 `;
 
+// OpenClaw 2026.4.11 format: region contains only reviewer info (name, photo,
+// location). Rating, date, and review text are siblings at the same indent
+// level. No `/url:` lines — userId is derived from slugified reviewer name.
+const NEW_FORMAT_SNAPSHOT = `
+      - region "Alice B." [ref=e3]:
+        - link "Photo of Alice B." [ref=e4]
+          - image "Photo of Alice B."
+        - link "Alice B." [ref=e5]
+          - statictext "Alice B."
+        - statictext "Temple City, CA"
+      - image "5 star rating"
+      - statictext "Apr 1, 2026"
+      - statictext "Amazing shaved ice!"
+      - button "Helpful (0 reactions)" [ref=e10]
+      - region "Recommended Reviews" [ref=e20]:
+`;
+
 describe("extractTabIds", () => {
   test("extracts all tab targetIds from openclaw tabs JSON output", () => {
     const output = `{
@@ -133,9 +150,8 @@ describe("parseReviewsFromSnapshot", () => {
     expect(reviews).toHaveLength(0);
   });
 
-  test("skips review blocks missing required fields", () => {
-    // Missing userId
-    const noUserId = `
+  test("falls back to slugified name when userId URL is absent", () => {
+    const snapshot = `
 - list [ref=e1]:
   - listitem [ref=e2]:
     - region "Bob C." [ref=e3]:
@@ -144,8 +160,12 @@ describe("parseReviewsFromSnapshot", () => {
       - paragraph [ref=e6]: Great place
   - listitem [ref=e7]:
 `;
-    expect(parseReviewsFromSnapshot(noUserId)).toHaveLength(0);
+    const reviews = parseReviewsFromSnapshot(snapshot);
+    expect(reviews).toHaveLength(1);
+    expect(reviews[0].userId).toBe("bob-c");
+  });
 
+  test("skips review blocks missing required fields", () => {
     // Missing rating
     const noRating = `
 - list [ref=e1]:
@@ -297,5 +317,238 @@ describe("parseReviewsFromSnapshot", () => {
       + "The service kinda sucked.\n\n"
       + "Ambiance is good but the table was sticky."
     );
+  });
+
+  test("parses a valid review from new openclaw format", () => {
+    const reviews = parseReviewsFromSnapshot(NEW_FORMAT_SNAPSHOT);
+
+    expect(reviews).toHaveLength(1);
+    expect(reviews[0].userId).toBe("alice-b");
+    expect(reviews[0].reviewerName).toBe("Alice B.");
+    expect(reviews[0].reviewerLocation).toBe("Temple City, CA");
+    expect(reviews[0].rating).toBe(5);
+    expect(reviews[0].postedAtRaw).toBe("Apr 1, 2026");
+    expect(reviews[0].postedAtIso).toBe("2026-04-01");
+    expect(reviews[0].reviewText).toBe("Amazing shaved ice!");
+    expect(reviews[0].fetchedAtIso).toBeDefined();
+  });
+
+  test("skips new-format review blocks missing required fields", () => {
+    // Missing rating
+    const noRating = `
+      - region "Bob C." [ref=e10]:
+        - link "Bob C." [ref=e11]
+          - statictext "Bob C."
+        - statictext "San Diego, CA"
+      - statictext "Mar 15, 2026"
+      - statictext "Great place"
+      - region "Recommended Reviews" [ref=e20]:
+`;
+    expect(parseReviewsFromSnapshot(noRating)).toHaveLength(0);
+
+    // Missing date
+    const noDate = `
+      - region "Bob C." [ref=e10]:
+        - link "Bob C." [ref=e11]
+          - statictext "Bob C."
+        - statictext "San Diego, CA"
+      - image "4 star rating"
+      - statictext "Great place"
+      - region "Recommended Reviews" [ref=e20]:
+`;
+    expect(parseReviewsFromSnapshot(noDate)).toHaveLength(0);
+
+    // Missing review text (only location and date statictext)
+    const noText = `
+      - region "Bob C." [ref=e10]:
+        - link "Bob C." [ref=e11]
+          - statictext "Bob C."
+        - statictext "San Diego, CA"
+      - image "4 star rating"
+      - statictext "Mar 15, 2026"
+      - region "Recommended Reviews" [ref=e20]:
+`;
+    expect(parseReviewsFromSnapshot(noText)).toHaveLength(0);
+  });
+
+  test("ignores business-owner widget in new format", () => {
+    const snapshot = `
+      - region "lisa j." [ref=e10]:
+        - link "lisa j." [ref=e11]
+          - statictext "lisa j."
+        - statictext "San Diego, CA"
+      - image "1 star rating"
+      - statictext "Apr 5, 2026"
+      - statictext "Maybe I ordered the wrong drink."
+      - linebreak
+      - linebreak
+      - statictext "I do not recommend Meet Fresh."
+      - button "Helpful (0 reactions)" [ref=e16]
+      - region "Business owner information" [ref=e18]:
+        - statictext "Business owner information"
+        - image "Photo of Store M."
+        - statictext "Store M."
+      - generic
+        - statictext "Apr 5, 2026"
+        - statictext "Thank you for visiting!"
+      - region "Alan X." [ref=e30]:
+`;
+    const reviews = parseReviewsFromSnapshot(snapshot);
+
+    expect(reviews).toHaveLength(1);
+    expect(reviews[0].reviewText).not.toContain("Business owner information");
+    expect(reviews[0].reviewText).not.toContain("Thank you for visiting!");
+    expect(reviews[0].reviewText).toContain("Maybe I ordered the wrong drink.");
+    expect(reviews[0].reviewText).toContain("I do not recommend Meet Fresh.");
+  });
+
+  test("parses multiple reviews from new-format snapshot", () => {
+    const snapshot = `
+      - region "Alice B." [ref=e3]:
+        - link "Alice B." [ref=e5]
+          - statictext "Alice B."
+        - statictext "Temple City, CA"
+      - image "5 star rating"
+      - statictext "Apr 1, 2026"
+      - statictext "Amazing shaved ice!"
+      - button "Helpful (0 reactions)" [ref=e10]
+      - region "Bob C." [ref=e11]:
+        - link "Bob C." [ref=e12]
+          - statictext "Bob C."
+        - statictext "Pasadena, CA"
+      - image "3 star rating"
+      - statictext "Mar 20, 2026"
+      - statictext "It was okay."
+      - button "Helpful (0 reactions)" [ref=e18]
+      - region "Recommended Reviews" [ref=e20]:
+`;
+    const reviews = parseReviewsFromSnapshot(snapshot);
+
+    expect(reviews).toHaveLength(2);
+    expect(reviews[0].reviewerName).toBe("Alice B.");
+    expect(reviews[0].userId).toBe("alice-b");
+    expect(reviews[0].reviewText).toBe("Amazing shaved ice!");
+    expect(reviews[1].reviewerName).toBe("Bob C.");
+    expect(reviews[1].userId).toBe("bob-c");
+    expect(reviews[1].reviewText).toBe("It was okay.");
+  });
+
+  test("joins multi-paragraph statictext in new format", () => {
+    const snapshot = `
+      - region "Bob C." [ref=e10]:
+        - link "Bob C." [ref=e11]
+          - statictext "Bob C."
+        - statictext "San Diego, CA"
+      - image "4 star rating"
+      - statictext "Mar 15, 2026"
+      - statictext "First paragraph of the review."
+      - linebreak
+      - linebreak
+      - statictext "Second paragraph of the review."
+      - linebreak
+      - linebreak
+      - statictext "Third paragraph."
+      - button "Helpful (0 reactions)" [ref=e20]
+      - region "Recommended Reviews" [ref=e21]:
+`;
+    const reviews = parseReviewsFromSnapshot(snapshot);
+
+    expect(reviews).toHaveLength(1);
+    expect(reviews[0].reviewText).toBe(
+      "First paragraph of the review.\n\n"
+      + "Second paragraph of the review.\n\n"
+      + "Third paragraph."
+    );
+  });
+
+  test("preserves review text that contains a city/state pattern", () => {
+    const snapshot = `
+      - region "Bob C." [ref=e10]:
+        - link "Bob C." [ref=e11]
+          - statictext "Bob C."
+        - statictext "San Diego, CA"
+      - image "4 star rating"
+      - statictext "Mar 15, 2026"
+      - statictext "I loved the boba in Pasadena, CA"
+      - button "Helpful (0 reactions)" [ref=e20]
+      - region "Recommended Reviews" [ref=e21]:
+`;
+    const reviews = parseReviewsFromSnapshot(snapshot);
+
+    expect(reviews).toHaveLength(1);
+    expect(reviews[0].reviewText).toBe("I loved the boba in Pasadena, CA");
+  });
+
+  test("does not drop reviewers with non-ASCII names", () => {
+    const snapshot = `
+      - region "李明." [ref=e10]:
+        - link "李明." [ref=e11]
+          - statictext "李明."
+        - statictext "San Gabriel, CA"
+      - image "5 star rating"
+      - statictext "Apr 10, 2026"
+      - statictext "Best boba ever!"
+      - region "Recommended Reviews" [ref=e20]:
+`;
+    const reviews = parseReviewsFromSnapshot(snapshot);
+
+    expect(reviews).toHaveLength(1);
+    expect(reviews[0].userId).toBe("unknown");
+    expect(reviews[0].reviewText).toBe("Best boba ever!");
+  });
+
+  test("nested child region does not prematurely end the review block", () => {
+    const snapshot = `
+      - region "Alice B." [ref=e3]:
+        - link "Alice B." [ref=e5]
+          - statictext "Alice B."
+        - statictext "Temple City, CA"
+        - region "Photos" [ref=e6]:
+          - image "Photo 1"
+      - image "5 star rating"
+      - statictext "Apr 1, 2026"
+      - statictext "Amazing shaved ice!"
+      - region "Recommended Reviews" [ref=e20]:
+`;
+    const reviews = parseReviewsFromSnapshot(snapshot);
+
+    expect(reviews).toHaveLength(1);
+    expect(reviews[0].reviewerName).toBe("Alice B.");
+    expect(reviews[0].rating).toBe(5);
+    expect(reviews[0].reviewText).toBe("Amazing shaved ice!");
+  });
+
+  test("does not misattribute review text as reviewer location", () => {
+    const snapshot = `
+      - region "Alice B." [ref=e3]:
+        - link "Alice B." [ref=e5]
+          - statictext "Alice B."
+      - image "5 star rating"
+      - statictext "Apr 1, 2026"
+      - statictext "Loved the one in Pasadena, CA"
+      - region "Recommended Reviews" [ref=e20]:
+`;
+    const reviews = parseReviewsFromSnapshot(snapshot);
+
+    expect(reviews).toHaveLength(1);
+    expect(reviews[0].reviewerLocation).toBeNull();
+    expect(reviews[0].reviewText).toBe("Loved the one in Pasadena, CA");
+  });
+
+  test("fallback userId is stable across re-parses and edits", () => {
+    const makeSnapshot = (text: string) => `
+      - region "Alice B." [ref=e3]:
+        - link "Alice B." [ref=e5]
+          - statictext "Alice B."
+        - statictext "Temple City, CA"
+      - image "5 star rating"
+      - statictext "Apr 1, 2026"
+      - statictext "${text}"
+      - region "Recommended Reviews" [ref=e20]:
+`;
+    const before = parseReviewsFromSnapshot(makeSnapshot("Amazing shaved ice!"));
+    const after = parseReviewsFromSnapshot(makeSnapshot("Updated: pretty good shaved ice."));
+
+    expect(before[0].userId).toBe(after[0].userId);
   });
 });


### PR DESCRIPTION
## Summary

- Updates the snapshot parser to handle OpenClaw 2026.4.11's new accessibility snapshot format (`image` instead of `img`, `statictext` instead of `generic`/`paragraph`, regions without trailing colons, review content as siblings rather than children)
- Falls back to a slugified reviewer name when the real Yelp user ID is unavailable (new format omits `/url:` lines)
- Adds comprehensive tests for the new format including multi-paragraph reviews, missing fields, business-owner widget filtering, and multiple reviews

## Test plan

- [x] Existing tests still pass (old format unchanged)
- [x] New tests cover: single review, multiple reviews, multi-paragraph text, missing required fields, business-owner widget exclusion, userId fallback

Closes #31, closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)